### PR TITLE
Show cookie settings by click on a respective button shown in footer

### DIFF
--- a/website/src/footer-content.tsx
+++ b/website/src/footer-content.tsx
@@ -31,13 +31,16 @@ const footerStyle = makeStyles((theme: Theme) => ({
     },
     legalText: {
         fontWeight: theme.typography.fontWeightLight
+    },
+    toolbarManageCookies: {
+        fontWeight: theme.typography.fontWeightLight
     }
 }));
 
 const FooterContent: React.FunctionComponent<{ expanded: boolean }> = ({ expanded }) => {
     const classes = footerStyle();
     const theme = useTheme();
-    const isSmallDisplay = useMediaQuery(theme.breakpoints.down('sm'));
+    const isSmallDisplay = useMediaQuery(theme.breakpoints.down('lg'));
     const isLargeDisplay = useMediaQuery(theme.breakpoints.up('xl'));
 
     const MainFooter = () => {
@@ -67,6 +70,9 @@ const FooterContent: React.FunctionComponent<{ expanded: boolean }> = ({ expande
                     </Box>
                     <Box ml={itemSpacing}>
                         {rightsReservedText(classes)}
+                    </Box>
+                    <Box ml={itemSpacing}>
+                        {manageCookies(classes)}
                     </Box>
                 </Box>
                 :
@@ -98,6 +104,9 @@ const FooterContent: React.FunctionComponent<{ expanded: boolean }> = ({ expande
                 </Box>
                 <Box mb={itemSpacing + 1}>
                     {legalResources(classes)}
+                </Box>
+                <Box mb={itemSpacing + 1}>
+                    {manageCookies(classes)}
                 </Box>
             </Box>
             <MainFooter />
@@ -165,5 +174,23 @@ const rightsReservedText = (classes: FooterStyle) =>
     <Box className={classes.legalText}>
         All Rights Reserved.
     </Box>;
+
+const manageCookies = (classes: FooterStyle) => {
+    const handleClick = () => {
+        const ccWindow = document.getElementsByClassName('cc-window').item(0);
+        if(ccWindow) {
+            ccWindow.setAttribute('style', 'display:flex');
+            setTimeout(function() {
+              ccWindow.classList.remove('cc-invisible');
+            }, 20);
+        }
+    }
+    return <Link 
+        onClick={handleClick}
+        className={classes.link + ' ' + classes.toolbarManageCookies}>
+            Manage Cookies
+    </Link>;
+}
+
 
 export default FooterContent;


### PR DESCRIPTION
A "Manage Cookies" link gets shown in footer. A click on it opens the cookie consent banner again. 

Still work in progress:

- [ ] clean up footer by hiding some items generally in a dropdown field (open for other suggestions)
- [ ] when user clicks on a banner button after reopening it it does not react - are the respective handlers removed after first consent action?

Fixes EclipseFdn/open-vsx.org#220