### PR TITLE
add Eclipse Foundation Google Tag Manager

### DIFF
--- a/website/static/index.html
+++ b/website/static/index.html
@@ -51,6 +51,7 @@
         }
     </style>
 </head>
+
 <body>
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5WLCZXC" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -26,6 +26,14 @@
     <meta name="twitter:description" content="Open VSX is a vendor-neutral open-source alternative to the Visual Studio Marketplace. It provides a server application that manages VS Code extensions in a database, a web application similar to the VS Code Marketplace, and a command-line tool for publishing extensions similar to vsce.">
     <meta name="twitter:image" content="https://open-vsx.org/openvsx-preview.png">
 
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5WLCZXC');</script>
+
+    <!-- Eclipse Cookie Consent -->
     <link rel="stylesheet" type="text/css"
         href="//www.eclipse.org/eclipse.org-common/themes/solstice/public/stylesheets/vendor/cookieconsent/cookieconsent.min.css" />
     <script
@@ -43,8 +51,10 @@
         }
     </style>
 </head>
-
 <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5WLCZXC" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="main"></div>
     <script src='/bundle.js' ></script>
 </body>


### PR DESCRIPTION
Signed-off-by: Christopher Guindon
<chris.guindon@eclipse-foundation.org>