### PR TITLE
Test what happens when file is already present in Azure Blob Storage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:7f4bb8d
+FROM docker.io/amvanbaren/openvsx-server:0fe5aca
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/


### PR DESCRIPTION
This is accomplished by commenting out `storageUtil.removeFile()` when unpublishing an extension.