### PR TITLE
Update image to f14d956

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM docker.io/amvanbaren/openvsx-server:0fe5aca
+FROM ghcr.io/eclipse/openvsx-server:f14d956
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/


### PR DESCRIPTION
Contains PRs: 

- https://github.com/eclipse/openvsx/pull/396
- https://github.com/eclipse/openvsx/pull/394
- https://github.com/eclipse/openvsx/pull/389

Dependabot updates: 

- `follow-redirects` from 1.13.2 to 1.14.7 in /cli
- `markdown-it` from 12.0.2 to 12.3.2 in /webui