### PR TITLE
Release 4119811

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,14 @@ RUN curl -sSL https://deb.nodesource.com/setup_12.x | bash - \
 RUN npm install --global yarn@1.*
 
 # bump to update website
-ENV WEBSITE_VERSION 0.1.1-next.153a429
+ENV WEBSITE_VERSION 0.2.0-next.4119811
 COPY . /workdir
 
 RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:153a429
+FROM ghcr.io/eclipse/openvsx-server:4119811
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/


### PR DESCRIPTION
Contains PRs:
https://github.com/eclipse/openvsx/pull/406
https://github.com/eclipse/openvsx/pull/433
https://github.com/eclipse/openvsx/pull/424
[feat: Add support for X-Forwarded-Prefix](https://github.com/eclipse/openvsx/commit/ea2cde9e079f932c7b30819213fa802066ad7c5f)
https://github.com/eclipse/openvsx/pull/419
https://github.com/eclipse/openvsx/pull/421
https://github.com/eclipse/openvsx/pull/422
https://github.com/eclipse/openvsx/pull/410

Dependabot updates:
[Bump ajv from 6.12.2 to 6.12.6 in /webui](https://github.com/eclipse/openvsx/commit/f475efa0495393d6b71cb5512b5a4392afce2115)
[Bump follow-redirects from 1.14.7 to 1.14.8 in /cli](https://github.com/eclipse/openvsx/commit/4f8445cd16290a2018c27d741afb10e59892373d)
[Bump pathval from 1.1.0 to 1.1.1 in /webui](https://github.com/eclipse/openvsx/commit/a477256404eb7171fcb648332995df6e78e7dffb)
[Bump simple-get from 3.1.0 to 3.1.1 in /cli](https://github.com/eclipse/openvsx/commit/2a2d53769346e85fba83092c83004ebd9fdd5085)