### PR TITLE
Release 19286bf hotfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM docker.io/amvanbaren/openvsx-server:b386833
+FROM ghcr.io/eclipse/openvsx-server:df28c16
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -17,6 +17,8 @@ spring:
   datasource:
     hikari:
       maximum-pool-size: 10
+  flyway:
+    baseline-on-migrate: false
   jpa:
     open-in-view: false
     properties:


### PR DESCRIPTION
Run extract resources migration as background jobs using JobRunr

Before deploying to `staging`, reset the database:
```
-- Reset migration 1.24
ALTER TABLE extension DROP COLUMN published_date;
ALTER TABLE extension DROP COLUMN last_updated_date;

-- Rerun database migrations
DELETE FROM flyway_schema_history WHERE version = '1.23' OR version = '1.24';
```