### PR TITLE
503 on https://open-vsx.org/ PR #485

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:df28c16
+FROM ghcr.io/eclipse/openvsx-server:25173d6
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/


### PR DESCRIPTION
The command below should now return a 400 bad request instead of a 503 internal server error.
```
curl --location --request POST 'https://staging.open-vsx.org/vscode/gallery/extensionquery' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json;api-version=3.0-preview.1' \
--data-raw '{"filters":[{"criteria":[{"filterType":10,"value":"php"},{"filterType":8,"value":"Microsoft.VisualStudio.Code"},{"filterType":12,"value":"4096"}],"pageNumber":201,"pageSize":50,"sortBy":0,"sortOrder":0}],"assetTypes":[],"flags":950}'
```