### PR TITLE
Release 1c2cc7d

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM docker.io/amvanbaren/openvsx-server:ecae6f7
+FROM docker.io/amvanbaren/openvsx-server:b386833
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM docker.io/amvanbaren/openvsx-server:134277e
+FROM ghcr.io/eclipse/openvsx-server:72706d1
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:72706d1
+FROM docker.io/amvanbaren/openvsx-server:ecae6f7
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/kubernetes/open-vsx.org.libsonnet
+++ b/kubernetes/open-vsx.org.libsonnet
@@ -51,6 +51,7 @@ local newDeployment(env, dockerImage) = {
   metadata: namespacedResourceMetadata(env),
   spec: {
     replicas: if (env.envName == "staging") then 1 else 2,
+    progressDeadlineSeconds: 3600,
     selector: {
       matchLabels: labels(env),
     },

--- a/kubernetes/open-vsx.org.libsonnet
+++ b/kubernetes/open-vsx.org.libsonnet
@@ -145,7 +145,7 @@ local newDeployment(env, dockerImage) = {
                 path: "/actuator/health/readiness",
                 port: "http-management"
               },
-              failureThreshold: 30,
+              failureThreshold: 360,
               periodSeconds: 10
             }
           },

--- a/website/src/footer-content.tsx
+++ b/website/src/footer-content.tsx
@@ -31,6 +31,10 @@ const footerStyle = makeStyles((theme: Theme) => ({
     },
     legalText: {
         fontWeight: theme.typography.fontWeightLight
+    },
+    cookieText: {
+        cursor: 'pointer',
+        fontWeight: 300
     }
 }));
 
@@ -61,6 +65,9 @@ const FooterContent: React.FunctionComponent<{ expanded: boolean }> = ({ expande
                     </Box>
                     <Box ml={itemSpacing}>
                         {legalResources(classes)}
+                    </Box>
+                    <Box ml={itemSpacing}>
+                        {manageCookies(classes)}
                     </Box>
                     <Box ml={itemSpacing}>
                         {copyrightText(classes)}
@@ -96,8 +103,11 @@ const FooterContent: React.FunctionComponent<{ expanded: boolean }> = ({ expande
                 <Box mb={itemSpacing}>
                     {copyrightAgent(classes)}
                 </Box>
-                <Box mb={itemSpacing + 1}>
+                <Box mb={itemSpacing}>
                     {legalResources(classes)}
+                </Box>
+                <Box mb={itemSpacing + 1}>
+                    {manageCookies(classes)}
                 </Box>
             </Box>
             <MainFooter />
@@ -166,4 +176,8 @@ const rightsReservedText = (classes: FooterStyle) =>
         All Rights Reserved.
     </Box>;
 
+const manageCookies = (classes: FooterStyle) =>
+    <Box className={`${classes.link} ${classes.cookieText} toolbar-manage-cookies`}>
+        Manage Cookies
+    </Box>;
 export default FooterContent;


### PR DESCRIPTION
### Performance Comparison
<details>
    <summary>/api/{namespace}</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    119 (OK=119    KO=-     )
> max response time                                    707 (OK=707    KO=-     )
> mean response time                                   134 (OK=134    KO=-     )
> std deviation                                         42 (OK=42     KO=-     )
> response time 50th percentile                        127 (OK=127    KO=-     )
> response time 75th percentile                        134 (OK=134    KO=-     )
> response time 95th percentile                        149 (OK=149    KO=-     )
> response time 99th percentile                        424 (OK=424    KO=-     )
> mean requests/sec                                 36.765 (OK=36.765 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          5000 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    123 (OK=123    KO=-     )
> max response time                                    681 (OK=681    KO=-     )
> mean response time                                   138 (OK=138    KO=-     )
> std deviation                                         43 (OK=43     KO=-     )
> response time 50th percentile                        131 (OK=131    KO=-     )
> response time 75th percentile                        138 (OK=138    KO=-     )
> response time 95th percentile                        153 (OK=153    KO=-     )
> response time 99th percentile                        393 (OK=393    KO=-     )
> mean requests/sec                                 35.714 (OK=35.714 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          5000 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4986   KO=14    )
> min response time                                    119 (OK=119    KO=129   )
> max response time                                    636 (OK=636    KO=159   )
> mean response time                                   134 (OK=134    KO=138   )
> std deviation                                         41 (OK=41     KO=9     )
> response time 50th percentile                        127 (OK=127    KO=135   )
> response time 75th percentile                        134 (OK=134    KO=145   )
> response time 95th percentile                        150 (OK=150    KO=151   )
> response time 99th percentile                        491 (OK=491    KO=157   )
> mean requests/sec                                 36.496 (OK=36.394 KO=0.102 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4986 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                14 (  0%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4986   KO=14    )
> min response time                                    128 (OK=132    KO=128   )
> max response time                                   3311 (OK=3311   KO=169   )
> mean response time                                   159 (OK=159    KO=139   )
> std deviation                                        136 (OK=137    KO=11    )
> response time 50th percentile                        146 (OK=146    KO=138   )
> response time 75th percentile                        154 (OK=154    KO=145   )
> response time 95th percentile                        173 (OK=173    KO=157   )
> response time 99th percentile                        529 (OK=529    KO=167   )
> mean requests/sec                                 31.056 (OK=30.969 KO=0.087 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4975 (100%)
> 800 ms < t < 1200 ms                                   1 (  0%)
> t > 1200 ms                                           10 (  0%)
> failed                                                14 (  0%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{version}</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4962   KO=38    )
> min response time                                    119 (OK=119    KO=126   )
> max response time                                   3017 (OK=3017   KO=161   )
> mean response time                                   137 (OK=137    KO=137   )
> std deviation                                         83 (OK=83     KO=9     )
> response time 50th percentile                        127 (OK=126    KO=136   )
> response time 75th percentile                        135 (OK=135    KO=143   )
> response time 95th percentile                        156 (OK=156    KO=153   )
> response time 99th percentile                        492 (OK=492    KO=161   )
> mean requests/sec                                 36.232 (OK=35.957 KO=0.275 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4956 ( 99%)
> 800 ms < t < 1200 ms                                   2 (  0%)
> t > 1200 ms                                            4 (  0%)
> failed                                                38 (  1%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     38 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4962   KO=38    )
> min response time                                    126 (OK=126    KO=130   )
> max response time                                    742 (OK=742    KO=163   )
> mean response time                                   143 (OK=143    KO=138   )
> std deviation                                         43 (OK=43     KO=6     )
> response time 50th percentile                        136 (OK=136    KO=137   )
> response time 75th percentile                        144 (OK=144    KO=140   )
> response time 95th percentile                        159 (OK=159    KO=146   )
> response time 99th percentile                        351 (OK=410    KO=157   )
> mean requests/sec                                 34.247 (OK=33.986 KO=0.26  )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4962 ( 99%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                38 (  1%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     38 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{version}/file/**</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8734 (OK=3734   KO=5000  )
> min response time                                     64 (OK=119    KO=64    )
> max response time                                   1150 (OK=1134   KO=1150  )
> mean response time                                   113 (OK=143    KO=90    )
> std deviation                                         53 (OK=49     KO=43    )
> response time 50th percentile                        123 (OK=137    KO=71    )
> response time 75th percentile                        140 (OK=144    KO=131   )
> response time 95th percentile                        156 (OK=161    KO=149   )
> response time 99th percentile                        221 (OK=503    KO=169   )
> mean requests/sec                                  43.67 (OK=18.67  KO=25    )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3733 ( 43%)
> 800 ms < t < 1200 ms                                   1 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 57%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   3734 (74,68%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1266 (25,32%)
ound 404
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       9725 (OK=4725   KO=5000  )
> min response time                                     70 (OK=123    KO=70    )
> max response time                                  21970 (OK=1157   KO=21970 )
> mean response time                                   116 (OK=148    KO=85    )
> std deviation                                        229 (OK=59     KO=311   )
> response time 50th percentile                        125 (OK=138    KO=73    )
> response time 75th percentile                        139 (OK=147    KO=77    )
> response time 95th percentile                        161 (OK=176    KO=139   )
> response time 99th percentile                        328 (OK=517    KO=169   )
> mean requests/sec                                 40.521 (OK=19.688 KO=20.833)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4718 ( 49%)
> 800 ms < t < 1200 ms                                   7 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 51%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   4725 (94,50%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f    275 ( 5,50%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/-/query</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    119 (OK=119    KO=-     )
> max response time                                   4014 (OK=4014   KO=-     )
> mean response time                                   135 (OK=135    KO=-     )
> std deviation                                        117 (OK=117    KO=-     )
> response time 50th percentile                        126 (OK=126    KO=-     )
> response time 75th percentile                        131 (OK=131    KO=-     )
> response time 95th percentile                        142 (OK=142    KO=-     )
> response time 99th percentile                        373 (OK=373    KO=-     )
> mean requests/sec                                 36.232 (OK=36.232 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4995 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            5 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    122 (OK=122    KO=-     )
> max response time                                    755 (OK=755    KO=-     )
> mean response time                                   138 (OK=138    KO=-     )
> std deviation                                         43 (OK=43     KO=-     )
> response time 50th percentile                        132 (OK=132    KO=-     )
> response time 75th percentile                        137 (OK=137    KO=-     )
> response time 95th percentile                        153 (OK=153    KO=-     )
> response time 99th percentile                        468 (OK=468    KO=-     )
> mean requests/sec                                 35.461 (OK=35.461 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          5000 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/-/search</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=3780   KO=1220  )
> min response time                                    125 (OK=125    KO=128   )
> max response time                                   8751 (OK=8751   KO=588   )
> mean response time                                   548 (OK=677    KO=147   )
> std deviation                                       1100 (OK=1237   KO=44    )
> response time 50th percentile                        185 (OK=241    KO=140   )
> response time 75th percentile                        329 (OK=535    KO=147   )
> response time 95th percentile                       2684 (OK=2998   KO=163   )
> response time 99th percentile                       7419 (OK=7616   KO=481   )
> mean requests/sec                                  9.042 (OK=6.835  KO=2.206 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3129 ( 63%)
> 800 ms < t < 1200 ms                                 148 (  3%)
> t > 1200 ms                                          503 ( 10%)
> failed                                              1220 ( 24%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1220 (100,0%)
ound 500
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=3780   KO=1220  )
> min response time                                    131 (OK=134    KO=131   )
> max response time                                   3573 (OK=3573   KO=2143  )
> mean response time                                   261 (OK=297    KO=151   )
> std deviation                                        306 (OK=342    KO=73    )
> response time 50th percentile                        163 (OK=174    KO=141   )
> response time 75th percentile                        195 (OK=218    KO=148   )
> response time 95th percentile                        874 (OK=975    KO=172   )
> response time 99th percentile                       1519 (OK=1634   KO=493   )
> mean requests/sec                                 18.939 (OK=14.318 KO=4.621 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3462 ( 69%)
> 800 ms < t < 1200 ms                                 224 (  4%)
> t > 1200 ms                                           94 (  2%)
> failed                                              1220 ( 24%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1220 (100,0%)
ound 400
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/gallery/extensionquery</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    151 (OK=151    KO=-     )
> max response time                                   2073 (OK=2073   KO=-     )
> mean response time                                   208 (OK=208    KO=-     )
> std deviation                                        114 (OK=114    KO=-     )
> response time 50th percentile                        172 (OK=172    KO=-     )
> response time 75th percentile                        196 (OK=196    KO=-     )
> response time 95th percentile                        305 (OK=305    KO=-     )
> response time 99th percentile                        911 (OK=911    KO=-     )
> mean requests/sec                                 22.422 (OK=22.422 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4943 ( 99%)
> 800 ms < t < 1200 ms                                  50 (  1%)
> t > 1200 ms                                            7 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    169 (OK=169    KO=-     )
> max response time                                   3640 (OK=3640   KO=-     )
> mean response time                                   282 (OK=282    KO=-     )
> std deviation                                        221 (OK=221    KO=-     )
> response time 50th percentile                        222 (OK=222    KO=-     )
> response time 75th percentile                        313 (OK=313    KO=-     )
> response time 95th percentile                        491 (OK=491    KO=-     )
> response time 99th percentile                       1163 (OK=1163   KO=-     )
> mean requests/sec                                 16.779 (OK=16.779 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4898 ( 98%)
> 800 ms < t < 1200 ms                                  60 (  1%)
> t > 1200 ms                                           42 (  1%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/asset/{namespace}/{extensionName}/{version}/{assetType}/**</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8850 (OK=3850   KO=5000  )
> min response time                                     64 (OK=120    KO=64    )
> max response time                                   2467 (OK=1663   KO=2467  )
> mean response time                                   115 (OK=148    KO=89    )
> std deviation                                         63 (OK=61     KO=51    )
> response time 50th percentile                        134 (OK=141    KO=72    )
> response time 75th percentile                        141 (OK=147    KO=84    )
> response time 95th percentile                        155 (OK=160    KO=147   )
> response time 99th percentile                        178 (OK=509    KO=163   )
> mean requests/sec                                 42.961 (OK=18.689 KO=24.272)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3845 ( 43%)
> 800 ms < t < 1200 ms                                   3 (  0%)
> t > 1200 ms                                            2 (  0%)
> failed                                              5000 ( 56%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      3850 (77,00%)
> status.find.is(200), but actually found 404                      1150 (23,00%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       9535 (OK=4535   KO=5000  )
> min response time                                     69 (OK=124    KO=69    )
> max response time                                   1153 (OK=1153   KO=547   )
> mean response time                                   113 (OK=149    KO=81    )
> std deviation                                         57 (OK=60     KO=29    )
> response time 50th percentile                        131 (OK=139    KO=72    )
> response time 75th percentile                        140 (OK=146    KO=76    )
> response time 95th percentile                        156 (OK=165    KO=139   )
> response time 99th percentile                        325 (OK=524    KO=155   )
> mean requests/sec                                 43.341 (OK=20.614 KO=22.727)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4528 ( 47%)
> 800 ms < t < 1200 ms                                   7 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 52%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      4535 (90,70%)
> status.find.is(200), but actually found 404                       465 ( 9,30%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/item</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      10000 (OK=10000  KO=0     )
> min response time                                    120 (OK=120    KO=-     )
> max response time                                   1152 (OK=1152   KO=-     )
> mean response time                                   135 (OK=135    KO=-     )
> std deviation                                         46 (OK=46     KO=-     )
> response time 50th percentile                        128 (OK=128    KO=-     )
> response time 75th percentile                        135 (OK=135    KO=-     )
> response time 95th percentile                        146 (OK=146    KO=-     )
> response time 99th percentile                        495 (OK=495    KO=-     )
> mean requests/sec                                  36.63 (OK=36.63  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          9995 (100%)
> 800 ms < t < 1200 ms                                   5 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      10000 (OK=10000  KO=0     )
> min response time                                    124 (OK=124    KO=-     )
> max response time                                   1144 (OK=1144   KO=-     )
> mean response time                                   139 (OK=139    KO=-     )
> std deviation                                         46 (OK=46     KO=-     )
> response time 50th percentile                        132 (OK=132    KO=-     )
> response time 75th percentile                        138 (OK=138    KO=-     )
> response time 95th percentile                        152 (OK=152    KO=-     )
> response time 99th percentile                        509 (OK=509    KO=-     )
> mean requests/sec                                 35.587 (OK=35.587 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          9996 (100%)
> 800 ms < t < 1200 ms                                   4 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/gallery/publishers/{namespace}/vsextensions/{extension}/{version}/vspackage</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      14924 (OK=9924   KO=5000  )
> min response time                                     64 (OK=119    KO=64    )
> max response time                                   1151 (OK=1151   KO=785   )
> mean response time                                   119 (OK=143    KO=71    )
> std deviation                                         55 (OK=51     KO=18    )
> response time 50th percentile                        127 (OK=137    KO=70    )
> response time 75th percentile                        140 (OK=144    KO=72    )
> response time 95th percentile                        156 (OK=161    KO=81    )
> response time 99th percentile                        343 (OK=497    KO=124   )
> mean requests/sec                                 41.456 (OK=27.567 KO=13.889)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          9916 ( 66%)
> 800 ms < t < 1200 ms                                   8 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 34%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      4962 (99,24%)
> status.find.is(200), but actually found 404                        38 ( 0,76%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      14924 (OK=9924   KO=5000  )
> min response time                                     70 (OK=123    KO=70    )
> max response time                                   1187 (OK=1187   KO=449   )
> mean response time                                   120 (OK=142    KO=76    )
> std deviation                                         51 (OK=48     KO=16    )
> response time 50th percentile                        130 (OK=135    KO=74    )
> response time 75th percentile                        138 (OK=142    KO=76    )
> response time 95th percentile                        154 (OK=160    KO=88    )
> response time 99th percentile                        210 (OK=507    KO=132   )
> mean requests/sec                                 41.341 (OK=27.49  KO=13.85 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          9920 ( 66%)
> 800 ms < t < 1200 ms                                   4 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 34%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      4962 (99,24%)
> status.find.is(200), but actually found 404                        38 ( 0,76%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>

### New Endpoint Performance
<details>
    <summary>/api/{namespace}/{extension}/{targetPlatform}</summary>
    <table>
        <tr>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4986   KO=14    )
> min response time                                    123 (OK=123    KO=131   )
> max response time                                   1267 (OK=1267   KO=156   )
> mean response time                                   141 (OK=141    KO=143   )
> std deviation                                         55 (OK=55     KO=9     )
> response time 50th percentile                        132 (OK=132    KO=143   )
> response time 75th percentile                        139 (OK=139    KO=152   )
> response time 95th percentile                        161 (OK=161    KO=156   )
> response time 99th percentile                        437 (OK=446    KO=156   )
> mean requests/sec                                 34.965 (OK=34.867 KO=0.098 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4980 (100%)
> 800 ms < t < 1200 ms                                   1 (  0%)
> t > 1200 ms                                            5 (  0%)
> failed                                                14 (  0%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{targetPlatform}/{version}</summary>
    <table>
        <tr>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4960   KO=40    )
> min response time                                    124 (OK=124    KO=133   )
> max response time                                  17209 (OK=17209  KO=10147 )
> mean response time                                   172 (OK=168    KO=681   )
> std deviation                                        493 (OK=452    KO=2177  )
> response time 50th percentile                        141 (OK=141    KO=152   )
> response time 75th percentile                        152 (OK=152    KO=173   )
> response time 95th percentile                        192 (OK=191    KO=1592  )
> response time 99th percentile                        551 (OK=548    KO=10147 )
> mean requests/sec                                 27.174 (OK=26.957 KO=0.217 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4948 ( 99%)
> 800 ms < t < 1200 ms                                   2 (  0%)
> t > 1200 ms                                           10 (  0%)
> failed                                                40 (  1%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     38 (95,00%)
ound 404
> i.n.h.s.SslHandshakeTimeoutException: handshake timed out afte      2 ( 5,00%)
r 10000ms
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{targetPlatform}/{version}/file/**</summary>
    <table>
        <tr>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8736 (OK=3736   KO=5000  )
> min response time                                     69 (OK=123    KO=69    )
> max response time                                   1380 (OK=1180   KO=1380  )
> mean response time                                   120 (OK=151    KO=97    )
> std deviation                                         60 (OK=59     KO=50    )
> response time 50th percentile                        131 (OK=140    KO=75    )
> response time 75th percentile                        144 (OK=151    KO=133   )
> response time 95th percentile                        170 (OK=180    KO=162   )
> response time 99th percentile                        355 (OK=517    KO=200   )
> mean requests/sec                                 41.208 (OK=17.623 KO=23.585)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3733 ( 43%)
> 800 ms < t < 1200 ms                                   3 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 57%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   3736 (74,72%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1264 (25,28%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/unpkg/{namespaceName}/{extensionName}/{version}/**</summary>
    <table>
        <tr>
            <th>Release 1c2cc7d</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       7481 (OK=4962   KO=2519  )
> min response time                                     69 (OK=123    KO=69    )
> max response time                                   1749 (OK=1749   KO=675   )
> mean response time                                   122 (OK=145    KO=79    )
> std deviation                                         66 (OK=69     KO=27    )
> response time 50th percentile                        130 (OK=135    KO=73    )
> response time 75th percentile                        139 (OK=144    KO=77    )
> response time 95th percentile                        163 (OK=169    KO=93    )
> response time 99th percentile                        315 (OK=513    KO=151   )
> mean requests/sec                                  40.22 (OK=26.677 KO=13.543)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4956 ( 66%)
> 800 ms < t < 1200 ms                                   1 (  0%)
> t > 1200 ms                                            5 (  0%)
> failed                                              2519 ( 34%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      2481 (98,49%)
> status.find.is(200), but actually found 404                        38 ( 1,51%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>