### PR TITLE
Release 5c0b2ae

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:1c2cc7d
+FROM ghcr.io/eclipse/openvsx-server:5c0b2ae
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM docker.io/amvanbaren/openvsx-server:09110fe
+FROM ghcr.io/eclipse/openvsx-server:1c2cc7d
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/


### PR DESCRIPTION
Uses system temp directory to store Ehcache files.

### Performance Comparison
<details>
    <summary>/api/{namespace}</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    119 (OK=119    KO=-     )
> max response time                                    707 (OK=707    KO=-     )
> mean response time                                   134 (OK=134    KO=-     )
> std deviation                                         42 (OK=42     KO=-     )
> response time 50th percentile                        127 (OK=127    KO=-     )
> response time 75th percentile                        134 (OK=134    KO=-     )
> response time 95th percentile                        149 (OK=149    KO=-     )
> response time 99th percentile                        424 (OK=424    KO=-     )
> mean requests/sec                                 36.765 (OK=36.765 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          5000 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    123 (OK=123    KO=-     )
> max response time                                   3167 (OK=3167   KO=-     )
> mean response time                                   141 (OK=141    KO=-     )
> std deviation                                        119 (OK=119    KO=-     )
> response time 50th percentile                        129 (OK=129    KO=-     )
> response time 75th percentile                        136 (OK=136    KO=-     )
> response time 95th percentile                        151 (OK=151    KO=-     )
> response time 99th percentile                        513 (OK=513    KO=-     )
> mean requests/sec                                 34.722 (OK=34.722 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4988 (100%)
> 800 ms < t < 1200 ms                                   4 (  0%)
> t > 1200 ms                                            8 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4986   KO=14    )
> min response time                                    119 (OK=119    KO=129   )
> max response time                                    636 (OK=636    KO=159   )
> mean response time                                   134 (OK=134    KO=138   )
> std deviation                                         41 (OK=41     KO=9     )
> response time 50th percentile                        127 (OK=127    KO=135   )
> response time 75th percentile                        134 (OK=134    KO=145   )
> response time 95th percentile                        150 (OK=150    KO=151   )
> response time 99th percentile                        491 (OK=491    KO=157   )
> mean requests/sec                                 36.496 (OK=36.394 KO=0.102 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4986 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                14 (  0%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4986   KO=14    )
> min response time                                    130 (OK=141    KO=130   )
> max response time                                   1420 (OK=1420   KO=381   )
> mean response time                                   181 (OK=181    KO=156   )
> std deviation                                        110 (OK=110    KO=63    )
> response time 50th percentile                        159 (OK=159    KO=139   )
> response time 75th percentile                        169 (OK=169    KO=148   )
> response time 95th percentile                        289 (OK=289    KO=231   )
> response time 99th percentile                        673 (OK=673    KO=351   )
> mean requests/sec                                 27.027 (OK=26.951 KO=0.076 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4946 ( 99%)
> 800 ms < t < 1200 ms                                  27 (  1%)
> t > 1200 ms                                           13 (  0%)
> failed                                                14 (  0%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{version}</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4962   KO=38    )
> min response time                                    119 (OK=119    KO=126   )
> max response time                                   3017 (OK=3017   KO=161   )
> mean response time                                   137 (OK=137    KO=137   )
> std deviation                                         83 (OK=83     KO=9     )
> response time 50th percentile                        127 (OK=126    KO=136   )
> response time 75th percentile                        135 (OK=135    KO=143   )
> response time 95th percentile                        156 (OK=156    KO=153   )
> response time 99th percentile                        492 (OK=492    KO=161   )
> mean requests/sec                                 36.232 (OK=35.957 KO=0.275 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4956 ( 99%)
> 800 ms < t < 1200 ms                                   2 (  0%)
> t > 1200 ms                                            4 (  0%)
> failed                                                38 (  1%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     38 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4962   KO=38    )
> min response time                                    126 (OK=126    KO=129   )
> max response time                                   2215 (OK=2215   KO=356   )
> mean response time                                   155 (OK=155    KO=147   )
> std deviation                                        102 (OK=103    KO=35    )
> response time 50th percentile                        138 (OK=138    KO=141   )
> response time 75th percentile                        148 (OK=148    KO=144   )
> response time 95th percentile                        174 (OK=174    KO=157   )
> response time 99th percentile                        610 (OK=611    KO=284   )
> mean requests/sec                                 31.847 (OK=31.605 KO=0.242 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4928 ( 99%)
> 800 ms < t < 1200 ms                                  23 (  0%)
> t > 1200 ms                                           11 (  0%)
> failed                                                38 (  1%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     38 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{version}/file/**</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8734 (OK=3734   KO=5000  )
> min response time                                     64 (OK=119    KO=64    )
> max response time                                   1150 (OK=1134   KO=1150  )
> mean response time                                   113 (OK=143    KO=90    )
> std deviation                                         53 (OK=49     KO=43    )
> response time 50th percentile                        123 (OK=137    KO=71    )
> response time 75th percentile                        140 (OK=144    KO=131   )
> response time 95th percentile                        156 (OK=161    KO=149   )
> response time 99th percentile                        221 (OK=503    KO=169   )
> mean requests/sec                                  43.67 (OK=18.67  KO=25    )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3733 ( 43%)
> 800 ms < t < 1200 ms                                   1 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 57%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   3734 (74,68%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1266 (25,32%)
ound 404
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       9727 (OK=4727   KO=5000  )
> min response time                                     68 (OK=123    KO=68    )
> max response time                                   2194 (OK=2194   KO=1233  )
> mean response time                                   113 (OK=152    KO=77    )
> std deviation                                         83 (OK=93     KO=50    )
> response time 50th percentile                        124 (OK=137    KO=69    )
> response time 75th percentile                        138 (OK=147    KO=72    )
> response time 95th percentile                        162 (OK=176    KO=133   )
> response time 99th percentile                        368 (OK=542    KO=161   )
> mean requests/sec                                  43.04 (OK=20.916 KO=22.124)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4704 ( 48%)
> 800 ms < t < 1200 ms                                  17 (  0%)
> t > 1200 ms                                            6 (  0%)
> failed                                              5000 ( 51%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   4727 (94,54%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f    273 ( 5,46%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/-/query</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    119 (OK=119    KO=-     )
> max response time                                   4014 (OK=4014   KO=-     )
> mean response time                                   135 (OK=135    KO=-     )
> std deviation                                        117 (OK=117    KO=-     )
> response time 50th percentile                        126 (OK=126    KO=-     )
> response time 75th percentile                        131 (OK=131    KO=-     )
> response time 95th percentile                        142 (OK=142    KO=-     )
> response time 99th percentile                        373 (OK=373    KO=-     )
> mean requests/sec                                 36.232 (OK=36.232 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4995 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            5 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    123 (OK=123    KO=-     )
> max response time                                    668 (OK=668    KO=-     )
> mean response time                                   134 (OK=134    KO=-     )
> std deviation                                         43 (OK=43     KO=-     )
> response time 50th percentile                        128 (OK=128    KO=-     )
> response time 75th percentile                        133 (OK=133    KO=-     )
> response time 95th percentile                        143 (OK=143    KO=-     )
> response time 99th percentile                        289 (OK=289    KO=-     )
> mean requests/sec                                 36.765 (OK=36.765 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          5000 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/-/search</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=3780   KO=1220  )
> min response time                                    125 (OK=125    KO=128   )
> max response time                                   8751 (OK=8751   KO=588   )
> mean response time                                   548 (OK=677    KO=147   )
> std deviation                                       1100 (OK=1237   KO=44    )
> response time 50th percentile                        185 (OK=241    KO=140   )
> response time 75th percentile                        329 (OK=535    KO=147   )
> response time 95th percentile                       2684 (OK=2998   KO=163   )
> response time 99th percentile                       7419 (OK=7616   KO=481   )
> mean requests/sec                                  9.042 (OK=6.835  KO=2.206 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3129 ( 63%)
> 800 ms < t < 1200 ms                                 148 (  3%)
> t > 1200 ms                                          503 ( 10%)
> failed                                              1220 ( 24%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1220 (100,0%)
ound 500
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=3780   KO=1220  )
> min response time                                    131 (OK=134    KO=131   )
> max response time                                   8757 (OK=8757   KO=1427  )
> mean response time                                   791 (OK=994    KO=163   )
> std deviation                                       1586 (OK=1776   KO=102   )
> response time 50th percentile                        184 (OK=252    KO=145   )
> response time 75th percentile                        366 (OK=550    KO=156   )
> response time 95th percentile                       5649 (OK=6173   KO=204   )
> response time 99th percentile                       6951 (OK=7024   KO=580   )
> mean requests/sec                                  6.274 (OK=4.743  KO=1.531 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          2992 ( 60%)
> 800 ms < t < 1200 ms                                 149 (  3%)
> t > 1200 ms                                          639 ( 13%)
> failed                                              1220 ( 24%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1220 (100,0%)
ound 400
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/gallery/extensionquery</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    151 (OK=151    KO=-     )
> max response time                                   2073 (OK=2073   KO=-     )
> mean response time                                   208 (OK=208    KO=-     )
> std deviation                                        114 (OK=114    KO=-     )
> response time 50th percentile                        172 (OK=172    KO=-     )
> response time 75th percentile                        196 (OK=196    KO=-     )
> response time 95th percentile                        305 (OK=305    KO=-     )
> response time 99th percentile                        911 (OK=911    KO=-     )
> mean requests/sec                                 22.422 (OK=22.422 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4943 ( 99%)
> 800 ms < t < 1200 ms                                  50 (  1%)
> t > 1200 ms                                            7 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    160 (OK=160    KO=-     )
> max response time                                   1812 (OK=1812   KO=-     )
> mean response time                                   295 (OK=295    KO=-     )
> std deviation                                        173 (OK=173    KO=-     )
> response time 50th percentile                        291 (OK=291    KO=-     )
> response time 75th percentile                        307 (OK=307    KO=-     )
> response time 95th percentile                        514 (OK=514    KO=-     )
> response time 99th percentile                       1214 (OK=1214   KO=-     )
> mean requests/sec                                 16.287 (OK=16.287 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4871 ( 97%)
> 800 ms < t < 1200 ms                                  75 (  2%)
> t > 1200 ms                                           54 (  1%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/asset/{namespace}/{extensionName}/{version}/{assetType}/**</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8850 (OK=3850   KO=5000  )
> min response time                                     64 (OK=120    KO=64    )
> max response time                                   2467 (OK=1663   KO=2467  )
> mean response time                                   115 (OK=148    KO=89    )
> std deviation                                         63 (OK=61     KO=51    )
> response time 50th percentile                        134 (OK=141    KO=72    )
> response time 75th percentile                        141 (OK=147    KO=84    )
> response time 95th percentile                        155 (OK=160    KO=147   )
> response time 99th percentile                        178 (OK=509    KO=163   )
> mean requests/sec                                 42.961 (OK=18.689 KO=24.272)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3845 ( 43%)
> 800 ms < t < 1200 ms                                   3 (  0%)
> t > 1200 ms                                            2 (  0%)
> failed                                              5000 ( 56%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      3850 (77,00%)
> status.find.is(200), but actually found 404                      1150 (23,00%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       9537 (OK=4537   KO=5000  )
> min response time                                     68 (OK=123    KO=68    )
> max response time                                   3244 (OK=3244   KO=1220  )
> mean response time                                   122 (OK=168    KO=81    )
> std deviation                                        131 (OK=170    KO=54    )
> response time 50th percentile                        129 (OK=141    KO=70    )
> response time 75th percentile                        141 (OK=151    KO=73    )
> response time 95th percentile                        166 (OK=194    KO=142   )
> response time 99th percentile                        544 (OK=1137   KO=169   )
> mean requests/sec                                 40.241 (OK=19.143 KO=21.097)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4488 ( 47%)
> 800 ms < t < 1200 ms                                  32 (  0%)
> t > 1200 ms                                           17 (  0%)
> failed                                              5000 ( 52%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      4537 (90,74%)
> status.find.is(200), but actually found 404                       463 ( 9,26%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/item</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      10000 (OK=10000  KO=0     )
> min response time                                    120 (OK=120    KO=-     )
> max response time                                   1152 (OK=1152   KO=-     )
> mean response time                                   135 (OK=135    KO=-     )
> std deviation                                         46 (OK=46     KO=-     )
> response time 50th percentile                        128 (OK=128    KO=-     )
> response time 75th percentile                        135 (OK=135    KO=-     )
> response time 95th percentile                        146 (OK=146    KO=-     )
> response time 99th percentile                        495 (OK=495    KO=-     )
> mean requests/sec                                  36.63 (OK=36.63  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          9995 (100%)
> 800 ms < t < 1200 ms                                   5 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      10000 (OK=10000  KO=0     )
> min response time                                    123 (OK=123    KO=-     )
> max response time                                   2204 (OK=2204   KO=-     )
> mean response time                                   151 (OK=151    KO=-     )
> std deviation                                        116 (OK=116    KO=-     )
> response time 50th percentile                        131 (OK=131    KO=-     )
> response time 75th percentile                        139 (OK=139    KO=-     )
> response time 95th percentile                        164 (OK=164    KO=-     )
> response time 99th percentile                        757 (OK=757    KO=-     )
> mean requests/sec                                 32.258 (OK=32.258 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          9901 ( 99%)
> 800 ms < t < 1200 ms                                  85 (  1%)
> t > 1200 ms                                           14 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/gallery/publishers/{namespace}/vsextensions/{extension}/{version}/vspackage</summary>
    <table>
        <tr>
            <th>Baseline 153a429</th>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      14924 (OK=9924   KO=5000  )
> min response time                                     64 (OK=119    KO=64    )
> max response time                                   1151 (OK=1151   KO=785   )
> mean response time                                   119 (OK=143    KO=71    )
> std deviation                                         55 (OK=51     KO=18    )
> response time 50th percentile                        127 (OK=137    KO=70    )
> response time 75th percentile                        140 (OK=144    KO=72    )
> response time 95th percentile                        156 (OK=161    KO=81    )
> response time 99th percentile                        343 (OK=497    KO=124   )
> mean requests/sec                                 41.456 (OK=27.567 KO=13.889)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          9916 ( 66%)
> 800 ms < t < 1200 ms                                   8 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 34%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      4962 (99,24%)
> status.find.is(200), but actually found 404                        38 ( 0,76%)
================================================================================
                </pre>
            </td>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      14924 (OK=9924   KO=5000  )
> min response time                                     68 (OK=123    KO=68    )
> max response time                                   3448 (OK=3448   KO=1191  )
> mean response time                                   128 (OK=157    KO=72    )
> std deviation                                        107 (OK=121    KO=22    )
> response time 50th percentile                        128 (OK=135    KO=69    )
> response time 75th percentile                        139 (OK=145    KO=72    )
> response time 95th percentile                        165 (OK=180    KO=73    )
> response time 99th percentile                        551 (OK=754    KO=128   )
> mean requests/sec                                 38.365 (OK=25.512 KO=12.853)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          9829 ( 66%)
> 800 ms < t < 1200 ms                                  79 (  1%)
> t > 1200 ms                                           16 (  0%)
> failed                                              5000 ( 34%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      4962 (99,24%)
> status.find.is(200), but actually found 404                        38 ( 0,76%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>

### New Endpoint Performance
<details>
    <summary>/api/{namespace}/{extension}/{targetPlatform}</summary>
    <table>
        <tr>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4986   KO=14    )
> min response time                                    123 (OK=123    KO=131   )
> max response time                                   1205 (OK=1205   KO=182   )
> mean response time                                   140 (OK=140    KO=143   )
> std deviation                                         69 (OK=69     KO=14    )
> response time 50th percentile                        128 (OK=128    KO=140   )
> response time 75th percentile                        136 (OK=136    KO=144   )
> response time 95th percentile                        154 (OK=154    KO=172   )
> response time 99th percentile                        513 (OK=513    KO=180   )
> mean requests/sec                                 35.461 (OK=35.362 KO=0.099 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4974 ( 99%)
> 800 ms < t < 1200 ms                                  11 (  0%)
> t > 1200 ms                                            1 (  0%)
> failed                                                14 (  0%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{targetPlatform}/{version}</summary>
    <table>
        <tr>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4962   KO=38    )
> min response time                                    123 (OK=123    KO=130   )
> max response time                                   1221 (OK=1221   KO=571   )
> mean response time                                   141 (OK=141    KO=156   )
> std deviation                                         64 (OK=64     KO=70    )
> response time 50th percentile                        130 (OK=130    KO=141   )
> response time 75th percentile                        138 (OK=138    KO=152   )
> response time 95th percentile                        163 (OK=162    KO=176   )
> response time 99th percentile                        510 (OK=509    KO=431   )
> mean requests/sec                                 34.965 (OK=34.699 KO=0.266 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4952 ( 99%)
> 800 ms < t < 1200 ms                                   8 (  0%)
> t > 1200 ms                                            2 (  0%)
> failed                                                38 (  1%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     38 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{targetPlatform}/{version}/file/**</summary>
    <table>
        <tr>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8734 (OK=3734   KO=5000  )
> min response time                                     68 (OK=123    KO=68    )
> max response time                                   1436 (OK=1436   KO=1217  )
> mean response time                                   118 (OK=148    KO=95    )
> std deviation                                         78 (OK=78     KO=70    )
> response time 50th percentile                        128 (OK=136    KO=71    )
> response time 75th percentile                        140 (OK=144    KO=131   )
> response time 95th percentile                        161 (OK=169    KO=156   )
> response time 99th percentile                        368 (OK=515    KO=349   )
> mean requests/sec                                  41.99 (OK=17.952 KO=24.038)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3722 ( 43%)
> 800 ms < t < 1200 ms                                   7 (  0%)
> t > 1200 ms                                            5 (  0%)
> failed                                              5000 ( 57%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   3734 (74,68%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1266 (25,32%)
ound 404
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/unpkg/{namespaceName}/{extensionName}/{version}/**</summary>
    <table>
        <tr>
            <th>Release 5c0b2ae</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       7481 (OK=4962   KO=2519  )
> min response time                                     68 (OK=123    KO=68    )
> max response time                                  22295 (OK=3387   KO=22295 )
> mean response time                                   124 (OK=146    KO=81    )
> std deviation                                        283 (OK=139    KO=444   )
> response time 50th percentile                        125 (OK=129    KO=69    )
> response time 75th percentile                        132 (OK=137    KO=72    )
> response time 95th percentile                        154 (OK=160    KO=75    )
> response time 99th percentile                        437 (OK=541    KO=136   )
> mean requests/sec                                 37.219 (OK=24.687 KO=12.532)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4936 ( 66%)
> 800 ms < t < 1200 ms                                  16 (  0%)
> t > 1200 ms                                           10 (  0%)
> failed                                              2519 ( 34%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      2481 (98,49%)
> status.find.is(200), but actually found 404                        38 ( 1,51%)
================================================================================
                </pre>
            </td>
        </tr>
    </table>
</details>