### PR TITLE
Release ea7e5f8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM docker.io/amvanbaren/openvsx-server:ecae6f7
+FROM docker.io/amvanbaren/openvsx-server:b386833
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM docker.io/amvanbaren/openvsx-server:134277e
+FROM ghcr.io/eclipse/openvsx-server:72706d1
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:72706d1
+FROM docker.io/amvanbaren/openvsx-server:ecae6f7
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
 
   options {
     buildDiscarder(logRotator(numToKeepStr: '10'))
+    timeout(time: 30, unit: 'MINUTES')
   }
 
   stages {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ yarn --cwd website build
 yarn --cwd website start:dev
 ```
 
-### Development
+### Development 
 
 We recommend running `watch:tsc` and `watch:dev` afterwards to run the TypeScript compiler and Webpack in watch mode.
 

--- a/kubernetes/open-vsx.org.libsonnet
+++ b/kubernetes/open-vsx.org.libsonnet
@@ -51,6 +51,7 @@ local newDeployment(env, dockerImage) = {
   metadata: namespacedResourceMetadata(env),
   spec: {
     replicas: if (env.envName == "staging") then 1 else 2,
+    progressDeadlineSeconds: 3600,
     selector: {
       matchLabels: labels(env),
     },

--- a/kubernetes/open-vsx.org.libsonnet
+++ b/kubernetes/open-vsx.org.libsonnet
@@ -145,7 +145,7 @@ local newDeployment(env, dockerImage) = {
                 path: "/actuator/health/readiness",
                 port: "http-management"
               },
-              failureThreshold: 30,
+              failureThreshold: 360,
               periodSeconds: 10
             }
           },

--- a/website/src/footer-content.tsx
+++ b/website/src/footer-content.tsx
@@ -31,6 +31,10 @@ const footerStyle = makeStyles((theme: Theme) => ({
     },
     legalText: {
         fontWeight: theme.typography.fontWeightLight
+    },
+    cookieText: {
+        cursor: 'pointer',
+        fontWeight: 300
     }
 }));
 
@@ -61,6 +65,9 @@ const FooterContent: React.FunctionComponent<{ expanded: boolean }> = ({ expande
                     </Box>
                     <Box ml={itemSpacing}>
                         {legalResources(classes)}
+                    </Box>
+                    <Box ml={itemSpacing}>
+                        {manageCookies(classes)}
                     </Box>
                     <Box ml={itemSpacing}>
                         {copyrightText(classes)}
@@ -96,8 +103,11 @@ const FooterContent: React.FunctionComponent<{ expanded: boolean }> = ({ expande
                 <Box mb={itemSpacing}>
                     {copyrightAgent(classes)}
                 </Box>
-                <Box mb={itemSpacing + 1}>
+                <Box mb={itemSpacing}>
                     {legalResources(classes)}
+                </Box>
+                <Box mb={itemSpacing + 1}>
+                    {manageCookies(classes)}
                 </Box>
             </Box>
             <MainFooter />
@@ -166,4 +176,8 @@ const rightsReservedText = (classes: FooterStyle) =>
         All Rights Reserved.
     </Box>;
 
+const manageCookies = (classes: FooterStyle) =>
+    <Box className={`${classes.link} ${classes.cookieText} toolbar-manage-cookies`}>
+        Manage Cookies
+    </Box>;
 export default FooterContent;


### PR DESCRIPTION
### Release Contains:
- webui SEO improvements
- Rate limiting
- Smaller db transactions
- `FileResource` processing in background job, so that `/api/-/publish` operation doesn't time out for larger extensions.
- Use `File` and `InputStream` for extension publishing, instread of (in memory) `byte` array.

### Performance Comparison
<details>
    <summary>/api/{namespace}</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    121 (OK=121    KO=-     )
> max response time                                    611 (OK=611    KO=-     )
> mean response time                                   134 (OK=134    KO=-     )
> std deviation                                         41 (OK=41     KO=-     )
> response time 50th percentile                        128 (OK=128    KO=-     )
> response time 75th percentile                        133 (OK=133    KO=-     )
> response time 95th percentile                        146 (OK=146    KO=-     )
> response time 99th percentile                        200 (OK=200    KO=-     )
> mean requests/sec                                 36.765 (OK=36.765 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          5000 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    121 (OK=121    KO=-     )
> max response time                                    842 (OK=842    KO=-     )
> mean response time                                   135 (OK=135    KO=-     )
> std deviation                                         44 (OK=44     KO=-     )
> response time 50th percentile                        128 (OK=128    KO=-     )
> response time 75th percentile                        134 (OK=134    KO=-     )
> response time 95th percentile                        148 (OK=148    KO=-     )
> response time 99th percentile                        267 (OK=267    KO=-     )
> mean requests/sec                                 36.232 (OK=36.232 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4995 (100%)
> 800 ms < t < 1200 ms                                   5 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4464   KO=536   )
> min response time                                    121 (OK=121    KO=124   )
> max response time                                    678 (OK=678    KO=590   )
> mean response time                                   136 (OK=136    KO=139   )
> std deviation                                         42 (OK=43     KO=32    )
> response time 50th percentile                        130 (OK=130    KO=134   )
> response time 75th percentile                        136 (OK=135    KO=141   )
> response time 95th percentile                        150 (OK=149    KO=153   )
> response time 99th percentile                        208 (OK=499    KO=165   )
> mean requests/sec                                 35.971 (OK=32.115 KO=3.856 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4464 ( 89%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                               536 ( 11%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 429                       536 (100,0%)
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4986   KO=14    )
> min response time                                    126 (OK=130    KO=126   )
> max response time                                    837 (OK=837    KO=510   )
> mean response time                                   149 (OK=149    KO=160   )
> std deviation                                         45 (OK=45     KO=97    )
> response time 50th percentile                        142 (OK=142    KO=134   )
> response time 75th percentile                        148 (OK=148    KO=136   )
> response time 95th percentile                        165 (OK=165    KO=269   )
> response time 99th percentile                        388 (OK=382    KO=462   )
> mean requests/sec                                 33.113 (OK=33.02  KO=0.093 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4981 (100%)
> 800 ms < t < 1200 ms                                   5 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                14 (  0%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4986   KO=14    )
> min response time                                    126 (OK=130    KO=126   )
> max response time                                   1207 (OK=1207   KO=153   )
> mean response time                                   151 (OK=151    KO=137   )
> std deviation                                         52 (OK=52     KO=8     )
> response time 50th percentile                        143 (OK=143    KO=134   )
> response time 75th percentile                        151 (OK=151    KO=143   )
> response time 95th percentile                        168 (OK=168    KO=151   )
> response time 99th percentile                        372 (OK=391    KO=153   )
> mean requests/sec                                  32.68 (OK=32.588 KO=0.092 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4980 (100%)
> 800 ms < t < 1200 ms                                   2 (  0%)
> t > 1200 ms                                            4 (  0%)
> failed                                                14 (  0%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 (100,0%)
ound 404
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=2154   KO=2846  )
> min response time                                    124 (OK=131    KO=124   )
> max response time                                    636 (OK=636    KO=581   )
> mean response time                                   143 (OK=153    KO=135   )
> std deviation                                         43 (OK=58     KO=23    )
> response time 50th percentile                        137 (OK=142    KO=132   )
> response time 75th percentile                        144 (OK=150    KO=138   )
> response time 95th percentile                        161 (OK=168    KO=151   )
> response time 99th percentile                        352 (OK=545    KO=165   )
> mean requests/sec                                 34.722 (OK=14.958 KO=19.764)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          2154 ( 43%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              2846 ( 57%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   2839 (99,75%)
ound 429
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f      7 ( 0,25%)
ound 404
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{targetPlatform}</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4986   KO=14    )
> min response time                                    121 (OK=121    KO=128   )
> max response time                                    610 (OK=610    KO=526   )
> mean response time                                   133 (OK=133    KO=166   )
> std deviation                                         41 (OK=40     KO=101   )
> response time 50th percentile                        127 (OK=127    KO=135   )
> response time 75th percentile                        131 (OK=131    KO=147   )
> response time 95th percentile                        145 (OK=145    KO=291   )
> response time 99th percentile                        254 (OK=249    KO=479   )
> mean requests/sec                                 37.037 (OK=36.933 KO=0.104 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4986 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                14 (  0%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4986   KO=14    )
> min response time                                    121 (OK=121    KO=132   )
> max response time                                    678 (OK=678    KO=156   )
> mean response time                                   135 (OK=135    KO=138   )
> std deviation                                         42 (OK=42     KO=7     )
> response time 50th percentile                        129 (OK=129    KO=137   )
> response time 75th percentile                        133 (OK=133    KO=139   )
> response time 95th percentile                        146 (OK=146    KO=152   )
> response time 99th percentile                        191 (OK=233    KO=155   )
> mean requests/sec                                 36.496 (OK=36.394 KO=0.102 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4986 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                14 (  0%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 (100,0%)
ound 404
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4765   KO=235   )
> min response time                                    121 (OK=121    KO=125   )
> max response time                                    638 (OK=638    KO=183   )
> mean response time                                   134 (OK=134    KO=136   )
> std deviation                                         41 (OK=42     KO=8     )
> response time 50th percentile                        128 (OK=128    KO=134   )
> response time 75th percentile                        133 (OK=133    KO=140   )
> response time 95th percentile                        148 (OK=147    KO=151   )
> response time 99th percentile                        367 (OK=495    KO=161   )
> mean requests/sec                                 36.765 (OK=35.037 KO=1.728 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4765 ( 95%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                               235 (  5%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f    221 (94,04%)
ound 429
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     14 ( 5,96%)
ound 404
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{version}</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4962   KO=38    )
> min response time                                    124 (OK=124    KO=129   )
> max response time                                    712 (OK=712    KO=169   )
> mean response time                                   140 (OK=140    KO=139   )
> std deviation                                         42 (OK=42     KO=9     )
> response time 50th percentile                        133 (OK=133    KO=137   )
> response time 75th percentile                        140 (OK=140    KO=143   )
> response time 95th percentile                        153 (OK=153    KO=159   )
> response time 99th percentile                        307 (OK=380    KO=166   )
> mean requests/sec                                 35.211 (OK=34.944 KO=0.268 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4962 ( 99%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                38 (  1%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     38 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4962   KO=38    )
> min response time                                    124 (OK=124    KO=130   )
> max response time                                    671 (OK=671    KO=181   )
> mean response time                                   140 (OK=140    KO=142   )
> std deviation                                         42 (OK=42     KO=13    )
> response time 50th percentile                        134 (OK=134    KO=138   )
> response time 75th percentile                        140 (OK=140    KO=146   )
> response time 95th percentile                        154 (OK=154    KO=171   )
> response time 99th percentile                        241 (OK=341    KO=180   )
> mean requests/sec                                 35.211 (OK=34.944 KO=0.268 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4962 ( 99%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                38 (  1%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     38 (100,0%)
ound 404
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=2123   KO=2877  )
> min response time                                    124 (OK=125    KO=124   )
> max response time                                    659 (OK=659    KO=632   )
> mean response time                                   141 (OK=147    KO=137   )
> std deviation                                         42 (OK=56     KO=27    )
> response time 50th percentile                        135 (OK=138    KO=133   )
> response time 75th percentile                        142 (OK=145    KO=139   )
> response time 95th percentile                        157 (OK=162    KO=153   )
> response time 99th percentile                        206 (OK=529    KO=169   )
> mean requests/sec                                 34.965 (OK=14.846 KO=20.119)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          2123 ( 42%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              2877 ( 58%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   2862 (99,48%)
ound 429
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     15 ( 0,52%)
ound 404
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{targetPlatform}/{version}</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4962   KO=38    )
> min response time                                    121 (OK=121    KO=130   )
> max response time                                    611 (OK=611    KO=164   )
> mean response time                                   134 (OK=134    KO=139   )
> std deviation                                         40 (OK=41     KO=8     )
> response time 50th percentile                        127 (OK=127    KO=136   )
> response time 75th percentile                        134 (OK=133    KO=141   )
> response time 95th percentile                        151 (OK=151    KO=158   )
> response time 99th percentile                        216 (OK=324    KO=163   )
> mean requests/sec                                 36.765 (OK=36.485 KO=0.279 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4962 ( 99%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                38 (  1%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     38 (100,0%)
ound 404
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4962   KO=38    )
> min response time                                    121 (OK=121    KO=128   )
> max response time                                    678 (OK=678    KO=170   )
> mean response time                                   136 (OK=135    KO=142   )
> std deviation                                         42 (OK=42     KO=10    )
> response time 50th percentile                        129 (OK=129    KO=140   )
> response time 75th percentile                        135 (OK=135    KO=148   )
> response time 95th percentile                        149 (OK=149    KO=161   )
> response time 99th percentile                        177 (OK=298    KO=168   )
> mean requests/sec                                 35.714 (OK=35.443 KO=0.271 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4962 ( 99%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                38 (  1%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     38 (100,0%)
ound 404
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4521   KO=479   )
> min response time                                    121 (OK=121    KO=124   )
> max response time                                    716 (OK=716    KO=543   )
> mean response time                                   136 (OK=135    KO=137   )
> std deviation                                         41 (OK=42     KO=27    )
> response time 50th percentile                        129 (OK=128    KO=133   )
> response time 75th percentile                        136 (OK=135    KO=140   )
> response time 95th percentile                        153 (OK=152    KO=156   )
> response time 99th percentile                        199 (OK=495    KO=172   )
> mean requests/sec                                 36.232 (OK=32.761 KO=3.471 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4521 ( 90%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                               479 ( 10%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f    445 (92,90%)
ound 429
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f     34 ( 7,10%)
ound 404
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{version}/file/**</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       9724 (OK=4724   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    693 (OK=693    KO=651   )
> mean response time                                   107 (OK=140    KO=74    )
> std deviation                                         47 (OK=43     KO=22    )
> response time 50th percentile                        122 (OK=136    KO=69    )
> response time 75th percentile                        136 (OK=142    KO=72    )
> response time 95th percentile                        151 (OK=158    KO=133   )
> response time 99th percentile                        172 (OK=495    KO=150   )
> mean requests/sec                                 46.305 (OK=22.495 KO=23.81 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4724 ( 49%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 51%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   4724 (94,48%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f    276 ( 5,52%)
ound 404
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       9727 (OK=4727   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    653 (OK=653    KO=541   )
> mean response time                                   107 (OK=141    KO=75    )
> std deviation                                         47 (OK=43     KO=23    )
> response time 50th percentile                        122 (OK=135    KO=69    )
> response time 75th percentile                        135 (OK=142    KO=72    )
> response time 95th percentile                        151 (OK=158    KO=132   )
> response time 99th percentile                        179 (OK=469    KO=152   )
> mean requests/sec                                 46.319 (OK=22.51  KO=23.81 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4727 ( 49%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 51%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   4727 (94,54%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f    273 ( 5,46%)
ound 404
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8314 (OK=3314   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    649 (OK=649    KO=557   )
> mean response time                                   113 (OK=144    KO=93    )
> std deviation                                         48 (OK=47     KO=37    )
> response time 50th percentile                        127 (OK=137    KO=71    )
> response time 75th percentile                        138 (OK=146    KO=130   )
> response time 95th percentile                        154 (OK=163    KO=143   )
> response time 99th percentile                        180 (OK=509    KO=155   )
> mean requests/sec                                 43.302 (OK=17.26  KO=26.042)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3314 ( 40%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 60%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   3314 (66,28%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1500 (30,00%)
ound 429
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f    186 ( 3,72%)
ound 404
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/{namespace}/{extension}/{targetPlatform}/{version}/file/**</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8730 (OK=3730   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    588 (OK=569    KO=588   )
> mean response time                                   111 (OK=140    KO=90    )
> std deviation                                         47 (OK=42     KO=40    )
> response time 50th percentile                        126 (OK=134    KO=71    )
> response time 75th percentile                        137 (OK=141    KO=130   )
> response time 95th percentile                        152 (OK=156    KO=148   )
> response time 99th percentile                        176 (OK=500    KO=166   )
> mean requests/sec                                 44.541 (OK=19.031 KO=25.51 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3730 ( 43%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 57%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   3730 (74,60%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1270 (25,40%)
ound 404
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8734 (OK=3734   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    711 (OK=711    KO=646   )
> mean response time                                   111 (OK=140    KO=90    )
> std deviation                                         48 (OK=43     KO=40    )
> response time 50th percentile                        127 (OK=134    KO=71    )
> response time 75th percentile                        137 (OK=141    KO=129   )
> response time 95th percentile                        152 (OK=156    KO=148   )
> response time 99th percentile                        179 (OK=500    KO=166   )
> mean requests/sec                                 44.561 (OK=19.051 KO=25.51 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3734 ( 43%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 57%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   3734 (74,68%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1266 (25,32%)
ound 404
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       7569 (OK=2569   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    660 (OK=657    KO=660   )
> mean response time                                   118 (OK=144    KO=105   )
> std deviation                                         49 (OK=46     KO=44    )
> response time 50th percentile                        131 (OK=138    KO=77    )
> response time 75th percentile                        140 (OK=146    KO=135   )
> response time 95th percentile                        156 (OK=163    KO=151   )
> response time 99th percentile                        188 (OK=515    KO=172   )
> mean requests/sec                                 41.361 (OK=14.038 KO=27.322)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          2569 ( 34%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 66%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   2569 (51,38%)
ound 403
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1616 (32,32%)
ound 429
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f    815 (16,30%)
ound 404
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/-/query</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    121 (OK=121    KO=-     )
> max response time                                    643 (OK=643    KO=-     )
> mean response time                                   133 (OK=133    KO=-     )
> std deviation                                         40 (OK=40     KO=-     )
> response time 50th percentile                        128 (OK=128    KO=-     )
> response time 75th percentile                        132 (OK=132    KO=-     )
> response time 95th percentile                        142 (OK=142    KO=-     )
> response time 99th percentile                        171 (OK=171    KO=-     )
> mean requests/sec                                 36.765 (OK=36.765 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          5000 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    121 (OK=121    KO=-     )
> max response time                                   1806 (OK=1806   KO=-     )
> mean response time                                   136 (OK=136    KO=-     )
> std deviation                                         62 (OK=62     KO=-     )
> response time 50th percentile                        127 (OK=127    KO=-     )
> response time 75th percentile                        132 (OK=132    KO=-     )
> response time 95th percentile                        143 (OK=143    KO=-     )
> response time 99th percentile                        402 (OK=402    KO=-     )
> mean requests/sec                                 36.232 (OK=36.232 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4995 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            5 (  0%)
> failed                                                 0 (  0%)
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    121 (OK=121    KO=-     )
> max response time                                   1033 (OK=1033   KO=-     )
> mean response time                                   135 (OK=135    KO=-     )
> std deviation                                         47 (OK=47     KO=-     )
> response time 50th percentile                        128 (OK=128    KO=-     )
> response time 75th percentile                        133 (OK=133    KO=-     )
> response time 95th percentile                        145 (OK=145    KO=-     )
> response time 99th percentile                        391 (OK=391    KO=-     )
> mean requests/sec                                 36.232 (OK=36.232 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4999 (100%)
> 800 ms < t < 1200 ms                                   1 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/api/-/search</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=3780   KO=1220  )
> min response time                                    127 (OK=132    KO=127   )
> max response time                                   3348 (OK=3348   KO=542   )
> mean response time                                   242 (OK=275    KO=142   )
> std deviation                                        259 (OK=290    KO=38    )
> response time 50th percentile                        156 (OK=167    KO=137   )
> response time 75th percentile                        181 (OK=197    KO=142   )
> response time 95th percentile                        869 (OK=953    KO=154   )
> response time 99th percentile                       1223 (OK=1265   KO=179   )
> mean requests/sec                                 20.325 (OK=15.366 KO=4.959 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3505 ( 70%)
> 800 ms < t < 1200 ms                                 216 (  4%)
> t > 1200 ms                                           59 (  1%)
> failed                                              1220 ( 24%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   1220 (100,0%)
ound 400
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    129 (OK=129    KO=-     )
> max response time                                   1814 (OK=1814   KO=-     )
> mean response time                                   238 (OK=238    KO=-     )
> std deviation                                        227 (OK=227    KO=-     )
> response time 50th percentile                        157 (OK=157    KO=-     )
> response time 75th percentile                        183 (OK=183    KO=-     )
> response time 95th percentile                        786 (OK=786    KO=-     )
> response time 99th percentile                       1180 (OK=1180   KO=-     )
> mean requests/sec                                 20.833 (OK=20.833 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4756 ( 95%)
> 800 ms < t < 1200 ms                                 197 (  4%)
> t > 1200 ms                                           47 (  1%)
> failed                                                 0 (  0%)
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=2778   KO=2222  )
> min response time                                    123 (OK=130    KO=123   )
> max response time                                   3298 (OK=3298   KO=544   )
> mean response time                                   234 (OK=313    KO=135   )
> std deviation                                        265 (OK=335    KO=24    )
> response time 50th percentile                        144 (OK=167    KO=131   )
> response time 75th percentile                        173 (OK=270    KO=138   )
> response time 95th percentile                        893 (OK=997    KO=149   )
> response time 99th percentile                       1190 (OK=1364   KO=163   )
> mean requests/sec                                 21.186 (OK=11.771 KO=9.415 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          2494 ( 50%)
> 800 ms < t < 1200 ms                                 236 (  5%)
> t > 1200 ms                                           48 (  1%)
> failed                                              2222 ( 44%)
---- Errors --------------------------------------------------------------------
> status.find.in(200,201,202,203,204,205,206,207,208,209,304), f   2222 (100,0%)
ound 429
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/gallery/extensionquery</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    159 (OK=159    KO=-     )
> max response time                                   1380 (OK=1380   KO=-     )
> mean response time                                   287 (OK=287    KO=-     )
> std deviation                                        127 (OK=127    KO=-     )
> response time 50th percentile                        287 (OK=287    KO=-     )
> response time 75th percentile                        297 (OK=297    KO=-     )
> response time 95th percentile                        414 (OK=414    KO=-     )
> response time 99th percentile                        955 (OK=955    KO=-     )
> mean requests/sec                                 16.892 (OK=16.892 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4902 ( 98%)
> 800 ms < t < 1200 ms                                  89 (  2%)
> t > 1200 ms                                            9 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=5000   KO=0     )
> min response time                                    156 (OK=156    KO=-     )
> max response time                                   1625 (OK=1625   KO=-     )
> mean response time                                   285 (OK=285    KO=-     )
> std deviation                                        122 (OK=122    KO=-     )
> response time 50th percentile                        286 (OK=286    KO=-     )
> response time 75th percentile                        297 (OK=297    KO=-     )
> response time 95th percentile                        401 (OK=401    KO=-     )
> response time 99th percentile                        951 (OK=951    KO=-     )
> mean requests/sec                                 17.007 (OK=17.007 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4912 ( 98%)
> 800 ms < t < 1200 ms                                  79 (  2%)
> t > 1200 ms                                            9 (  0%)
> failed                                                 0 (  0%)
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       5000 (OK=4234   KO=766   )
> min response time                                    124 (OK=159    KO=124   )
> max response time                                   3580 (OK=3580   KO=537   )
> mean response time                                   288 (OK=316    KO=137   )
> std deviation                                        199 (OK=205    KO=38    )
> response time 50th percentile                        290 (OK=294    KO=132   )
> response time 75th percentile                        307 (OK=312    KO=138   )
> response time 95th percentile                        451 (OK=479    KO=153   )
> response time 99th percentile                        975 (OK=992    KO=194   )
> mean requests/sec                                 16.722 (OK=14.161 KO=2.562 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4139 ( 83%)
> 800 ms < t < 1200 ms                                  69 (  1%)
> t > 1200 ms                                           26 (  1%)
> failed                                               766 ( 15%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 429                       766 (100,0%)
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/asset/{namespace}/{extensionName}/{version}/{assetType}/**</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       9535 (OK=4535   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    750 (OK=750    KO=533   )
> mean response time                                   108 (OK=143    KO=77    )
> std deviation                                         48 (OK=42     KO=26    )
> response time 50th percentile                        127 (OK=137    KO=69    )
> response time 75th percentile                        137 (OK=143    KO=72    )
> response time 95th percentile                        151 (OK=155    KO=137   )
> response time 99th percentile                        168 (OK=449    KO=152   )
> mean requests/sec                                 45.405 (OK=21.595 KO=23.81 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4535 ( 48%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 52%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      4535 (90,70%)
> status.find.is(200), but actually found 404                       465 ( 9,30%)
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       9537 (OK=4537   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                  22083 (OK=670    KO=22083 )
> mean response time                                   113 (OK=143    KO=87    )
> std deviation                                        321 (OK=43     KO=440   )
> response time 50th percentile                        128 (OK=136    KO=69    )
> response time 75th percentile                        137 (OK=143    KO=72    )
> response time 95th percentile                        152 (OK=157    KO=137   )
> response time 99th percentile                        180 (OK=404    KO=153   )
> mean requests/sec                                 41.286 (OK=19.641 KO=21.645)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4537 ( 48%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 52%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      4537 (90,74%)
> status.find.is(200), but actually found 404                       463 ( 9,26%)
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8296 (OK=3296   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    787 (OK=665    KO=787   )
> mean response time                                   115 (OK=144    KO=95    )
> std deviation                                         49 (OK=44     KO=42    )
> response time 50th percentile                        130 (OK=138    KO=73    )
> response time 75th percentile                        138 (OK=145    KO=129   )
> response time 95th percentile                        154 (OK=161    KO=145   )
> response time 99th percentile                        180 (OK=503    KO=162   )
> mean requests/sec                                 42.544 (OK=16.903 KO=25.641)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          3296 ( 40%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 60%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      3296 (65,92%)
> status.find.is(200), but actually found 429                      1327 (26,54%)
> status.find.is(200), but actually found 404                       377 ( 7,54%)
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/item</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      10000 (OK=10000  KO=0     )
> min response time                                    121 (OK=121    KO=-     )
> max response time                                    659 (OK=659    KO=-     )
> mean response time                                   135 (OK=135    KO=-     )
> std deviation                                         40 (OK=40     KO=-     )
> response time 50th percentile                        129 (OK=129    KO=-     )
> response time 75th percentile                        134 (OK=134    KO=-     )
> response time 95th percentile                        146 (OK=145    KO=-     )
> response time 99th percentile                        251 (OK=251    KO=-     )
> mean requests/sec                                  36.63 (OK=36.63  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                         10000 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      10000 (OK=10000  KO=0     )
> min response time                                    121 (OK=121    KO=-     )
> max response time                                    650 (OK=650    KO=-     )
> mean response time                                   135 (OK=135    KO=-     )
> std deviation                                         41 (OK=41     KO=-     )
> response time 50th percentile                        129 (OK=129    KO=-     )
> response time 75th percentile                        134 (OK=133    KO=-     )
> response time 95th percentile                        145 (OK=145    KO=-     )
> response time 99th percentile                        197 (OK=197    KO=-     )
> mean requests/sec                                 36.765 (OK=36.765 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                         10000 (100%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                                 0 (  0%)
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       8519 (OK=7038   KO=1481  )
> min response time                                    121 (OK=121    KO=124   )
> max response time                                    659 (OK=659    KO=533   )
> mean response time                                   137 (OK=137    KO=135   )
> std deviation                                         41 (OK=43     KO=26    )
> response time 50th percentile                        131 (OK=131    KO=131   )
> response time 75th percentile                        136 (OK=136    KO=136   )
> response time 95th percentile                        149 (OK=149    KO=149   )
> response time 99th percentile                        497 (OK=502    KO=168   )
> mean requests/sec                                 35.496 (OK=29.325 KO=6.171 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          7038 ( 83%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              1481 ( 17%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 429                      1481 (100,0%)
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/unpkg/{namespaceName}/{extensionName}/{version}/**</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       7481 (OK=4962   KO=2519  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    600 (OK=600    KO=396   )
> mean response time                                   113 (OK=134    KO=72    )
> std deviation                                         45 (OK=41     KO=15    )
> response time 50th percentile                        124 (OK=128    KO=69    )
> response time 75th percentile                        131 (OK=134    KO=71    )
> response time 95th percentile                        145 (OK=148    KO=75    )
> response time 99th percentile                        168 (OK=332    KO=134   )
> mean requests/sec                                 43.243 (OK=28.682 KO=14.561)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4962 ( 66%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              2519 ( 34%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      2481 (98,49%)
> status.find.is(200), but actually found 404                        38 ( 1,51%)
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       7481 (OK=4962   KO=2519  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    628 (OK=628    KO=438   )
> mean response time                                   113 (OK=135    KO=72    )
> std deviation                                         46 (OK=42     KO=17    )
> response time 50th percentile                        125 (OK=128    KO=69    )
> response time 75th percentile                        131 (OK=134    KO=71    )
> response time 95th percentile                        144 (OK=147    KO=74    )
> response time 99th percentile                        169 (OK=404    KO=135   )
> mean requests/sec                                 42.994 (OK=28.517 KO=14.477)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4962 ( 66%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              2519 ( 34%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      2481 (98,49%)
> status.find.is(200), but actually found 404                        38 ( 1,51%)
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                       7133 (OK=4299   KO=2834  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    743 (OK=743    KO=571   )
> mean response time                                   117 (OK=137    KO=88    )
> std deviation                                         48 (OK=45     KO=34    )
> response time 50th percentile                        127 (OK=129    KO=70    )
> response time 75th percentile                        133 (OK=136    KO=99    )
> response time 95th percentile                        149 (OK=153    KO=143   )
> response time 99th percentile                        185 (OK=500    KO=160   )
> mean requests/sec                                 41.471 (OK=24.994 KO=16.477)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          4299 ( 60%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              2834 ( 40%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      2133 (75,26%)
> status.find.is(200), but actually found 429                       668 (23,57%)
> status.find.is(200), but actually found 404                        33 ( 1,16%)
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>
<details>
    <summary>/vscode/gallery/publishers/{namespace}/vsextensions/{extension}/{version}/vspackage</summary>
    <table>
        <tr>
            <th>Baseline 99d5841</th>
			<th>Release 720d3d3</th>
			<th>Release 720d3d3 (rate-limited)</th>
        </tr>
        <tr>
            <td>
                <pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      14924 (OK=9924   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    664 (OK=664    KO=436   )
> mean response time                                   116 (OK=138    KO=71    )
> std deviation                                         47 (OK=41     KO=13    )
> response time 50th percentile                        127 (OK=133    KO=69    )
> response time 75th percentile                        136 (OK=139    KO=72    )
> response time 95th percentile                        150 (OK=154    KO=76    )
> response time 99th percentile                        174 (OK=439    KO=94    )
> mean requests/sec                                  42.64 (OK=28.354 KO=14.286)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          9924 ( 66%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 34%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      4962 (99,24%)
> status.find.is(200), but actually found 404                        38 ( 0,76%)
================================================================================
                </pre>
            </td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      14924 (OK=9924   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    656 (OK=656    KO=459   )
> mean response time                                   115 (OK=137    KO=71    )
> std deviation                                         46 (OK=41     KO=13    )
> response time 50th percentile                        128 (OK=132    KO=69    )
> response time 75th percentile                        134 (OK=138    KO=72    )
> response time 95th percentile                        148 (OK=151    KO=74    )
> response time 99th percentile                        165 (OK=459    KO=93    )
> mean requests/sec                                 43.133 (OK=28.682 KO=14.451)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          9924 ( 66%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 34%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      4962 (99,24%)
> status.find.is(200), but actually found 404                        38 ( 0,76%)
================================================================================
				</pre>
			</td>
			<td>
				<pre>
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      12474 (OK=7474   KO=5000  )
> min response time                                     68 (OK=121    KO=68    )
> max response time                                    634 (OK=634    KO=528   )
> mean response time                                   121 (OK=141    KO=90    )
> std deviation                                         48 (OK=44     KO=35    )
> response time 50th percentile                        130 (OK=135    KO=72    )
> response time 75th percentile                        138 (OK=143    KO=126   )
> response time 95th percentile                        154 (OK=158    KO=142   )
> response time 99th percentile                        187 (OK=509    KO=156   )
> mean requests/sec                                   40.5 (OK=24.266 KO=16.234)
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                          7474 ( 60%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            0 (  0%)
> failed                                              5000 ( 40%)
---- Errors --------------------------------------------------------------------
> status.find.is(200), but actually found 403                      3584 (71,68%)
> status.find.is(200), but actually found 429                      1384 (27,68%)
> status.find.is(200), but actually found 404                        32 ( 0,64%)
================================================================================
				</pre>
			</td>
        </tr>
    </table>
</details>

