### PR TITLE
Added component label to some resources to disambiguate selectors

### DIFF
--- a/kubernetes/open-vsx.org.libsonnet
+++ b/kubernetes/open-vsx.org.libsonnet
@@ -8,7 +8,9 @@ local labels(env) = {
 local namespacedResourceMetadata(env) = {
   name: "%s-%s" % [ env.appName, env.envName, ],
   namespace: env.namespace,
-  labels: labels(env),
+  labels: labels(env) {
+    component: "open-vsx-server",
+  },
 };
 
 local newEnvironment(envName) = {
@@ -53,11 +55,15 @@ local newDeployment(env, dockerImage) = {
     replicas: if (env.envName == "staging") then 1 else 2,
     progressDeadlineSeconds: 3600,
     selector: {
-      matchLabels: labels(env),
+      matchLabels: labels(env) {
+        component: 'open-vsx-server',
+      },
     },
     template: {
       metadata: {
-        labels: labels(env),
+        labels: labels(env) {
+          component: 'open-vsx-server',
+        },
       },
       spec: {
         local thisPod = self,
@@ -198,7 +204,9 @@ local newDeployment(env, dockerImage) = {
             topologyKey: "kubernetes.io/hostname",
             whenUnsatisfiable: "DoNotSchedule",
             labelSelector: {
-              matchLabels: labels(env),
+              matchLabels: labels(env) {
+                component: 'open-vsx-server',
+              },
             },
           },
         ],
@@ -212,7 +220,9 @@ local newService(env, deployment) = {
   kind: "Service",
   metadata: namespacedResourceMetadata(env),
   spec: {
-    selector: labels(env),
+    selector: labels(env) {
+      component: 'open-vsx-server',
+    },
     ports: utils.namedObjectList(self._ports),
     _ports:: {
       http: {
@@ -257,7 +267,9 @@ local newElasticSearchCluster(env) = {
   metadata: {
     name: env.elasticsearch.name,
     namespace: env.namespace,
-    labels: labels(env),
+    labels: labels(env) {
+      component: 'elasticsearch',
+    },
   },
   spec: {
     version: "7.9.3",
@@ -270,7 +282,9 @@ local newElasticSearchCluster(env) = {
         },
         podTemplate: {
           metadata: {
-            labels: labels(env),
+            labels: labels(env) {
+              component: 'elasticsearch',
+            },
           },
           spec: {
             containers: [


### PR DESCRIPTION
We are using the same labels set for both the server deployment and the elasticsearch statefulset. Kubectl CLI is confuses the matching pods when doing requests on deployments or statefulset as it probably uses the selector to find matching pods:

```
$ oc logs -n open-vsx-org deploy/open-vsx-org-production --tail=1
Found 7 pods, using pod/elasticsearch-production-es-default-2
```

This may also cause confuse the cluster, even though I have no proof of that.

This cannot be deployed as is as the labels of pod templates in deployments and statefulsets cannot be updated once created. I'll provide the steps shortly