### PR TITLE
Release 302a108

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM docker.io/amvanbaren/openvsx-server:c270634
+FROM docker.io/amvanbaren/openvsx-server:302a108
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/


### PR DESCRIPTION
Update Spring Boot to 2.7.0
Stops spamming of `Invalid mime type "api-version=6.1-preview.1"` errors in the logs.