### PR TITLE
[Feature] Add "Status" link in navigation menus 

### DIFF
--- a/website/src/menu-content.tsx
+++ b/website/src/menu-content.tsx
@@ -18,6 +18,7 @@ import HelpIcon from '@material-ui/icons/Help';
 import ForumIcon from '@material-ui/icons/Forum';
 import InfoIcon from '@material-ui/icons/Info';
 import StarIcon from '@material-ui/icons/Star';
+import StatusIcon from '@material-ui/icons/NetworkCheck';
 import PublishIcon from '@material-ui/icons/Publish';
 import { UserSettingsRoutes } from 'openvsx-webui';
 
@@ -110,6 +111,14 @@ export const MobileMenuContent: React.FunctionComponent = () => {
                 </Typography>
             </Link>
         </MenuItem>
+        <MenuItem className={classes.menuItem}>
+            <Link href='https://status.open-vsx.org/'>
+                <Typography variant='body2' color='textPrimary' className={classes.alignVertically}>
+                    <StatusIcon className={classes.itemIcon} />
+                    Status
+                </Typography>
+            </Link>
+        </MenuItem>
         {
             !location.pathname.startsWith(UserSettingsRoutes.ROOT)
             ? <MenuItem className={classes.menuItem}>
@@ -145,6 +154,9 @@ export const DefaultMenuContent: React.FunctionComponent = () => {
         </RouteLink>
         <Link href='https://www.eclipse.org/donate/openvsx/' className={classes.headerItem}>
             Sponsor
+        </Link>
+        <Link href='https://status.open-vsx.org/' className={classes.headerItem}>
+            Status
         </Link>
         <Button variant='contained' color='secondary' href='/user-settings/extensions' className={classes.publishButton}>
             Publish

--- a/website/src/menu-content.tsx
+++ b/website/src/menu-content.tsx
@@ -91,7 +91,7 @@ export const MobileMenuContent: React.FunctionComponent = () => {
             <Link href='https://gitter.im/eclipse/openvsx'>
                 <Typography variant='body2' color='textPrimary' className={classes.alignVertically}>
                     <ForumIcon className={classes.itemIcon} />
-                    Community Chat
+                    Community
                 </Typography>
             </Link>
         </MenuItem>
@@ -99,7 +99,7 @@ export const MobileMenuContent: React.FunctionComponent = () => {
             <RouteLink to='/about'>
                 <Typography variant='body2' color='textPrimary' className={classes.alignVertically}>
                     <InfoIcon className={classes.itemIcon} />
-                    About This Service
+                    About
                 </Typography>
             </RouteLink>
         </MenuItem>


### PR DESCRIPTION
This (hopefully) closes #1295 by adding a link to the [Status monitoring website](https://status.open-vsx.org) on the default and mobile navigation menus. The mobile menu displays icons, and I tried to use my best judgment when choosing a suitable one for "Status":

![image](https://user-images.githubusercontent.com/262645/202836381-48542d3e-dac8-46d3-9428-5c11b02b5c4c.png)
`network_check`

Note that I also took it upon myself to [rename two link titles](https://github.com/scar45/open-vsx.org/commit/9a275b48d63a4eb58a59f0757f1a20b478c2cb8c) in the menu for consistency with the default/desktop.

If any adjustments should be made, I would be happy to implement and update this PR. Thanks in advance for considering a merge!