### PR TITLE
Disable long request logging

### DIFF
--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -148,4 +148,4 @@ ovsx:
       seconds: 300
   request:
     duration:
-      threshold: 20000
+      threshold: 5000

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -146,6 +146,3 @@ ovsx:
   migrations:
     delay:
       seconds: 300
-  request:
-    duration:
-      threshold: 5000


### PR DESCRIPTION
The long request logging most likely worsens the server performance.