### PR TITLE
Release 0.11.0 fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:v0.11.0
+FROM ghcr.io/eclipse/openvsx-server:2252936
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:65f023e
+FROM ghcr.io/eclipse/openvsx-server:v0.11.0
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -146,5 +146,3 @@ ovsx:
   migrations:
     delay:
       seconds: 300
-  integrity:
-    key-pair: create


### PR DESCRIPTION
### What's changed?
- https://github.com/eclipse/openvsx/pull/728
- set `integrity.key-pair` mode to 'undefined', so that current migrations can finish but API responses don't include `signature` and `publicKey` files in their responses.