### PR TITLE
Assist testing eclipse-openvsx-api

### DIFF
--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -130,7 +130,7 @@ ovsx:
   webui:
     frontendRoutes: "/extension/**,/namespace/**,/user-settings/**,/admin-dashboard/**,/about,/publisher-agreement-*,/terms-of-use"
   eclipse:
-    base-url: https://api.eclipse.org/
+    base-url: https://api-staging.eclipse.org
     publisher-agreement:
       version: 1
       timezone: US/Eastern


### PR DESCRIPTION
Change ovsx.eclipse.base-url to https://api-staging.eclipse.org