### PR TITLE
Increase ElasticSearch RAM

### DIFF
--- a/kubernetes/open-vsx.org.libsonnet
+++ b/kubernetes/open-vsx.org.libsonnet
@@ -282,11 +282,11 @@ local newElasticSearchCluster(env) = {
                 },
                 resources: {
                   requests: {
-                    memory: if (env.envName == "staging") then "2Gi" else "6Gi",
+                    memory: if (env.envName == "staging") then "2Gi" else "8Gi",
                     cpu: 1
                   },
                   limits: {
-                    memory: if (env.envName == "staging") then "2Gi" else "6Gi",
+                    memory: if (env.envName == "staging") then "2Gi" else "8Gi",
                     cpu: if (env.envName == "staging") then 1 else 4,
                   }
                 }


### PR DESCRIPTION
The standard recommendation is to give 50% of the available memory to Elasticsearch heap, while leaving the other 50% free. It won’t go unused; Lucene will happily gobble up whatever is left over. Source: https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html#_give_less_than_half_your_memory_to_lucene