### PR TITLE
Remove redundant `backgroundImage` css rule

### DIFF
--- a/website/src/menu-content.tsx
+++ b/website/src/menu-content.tsx
@@ -73,7 +73,7 @@ export const MobileMenuContent: FunctionComponent = () => {
                 </MobileMenuItemText>
             </Link>
         </MobileMenuItem>
-        <Accordion sx={{border: 0, borderRadius: 0, boxShadow: '0 0', background: 'transparent', backgroundImage: 'none'}}>
+        <Accordion sx={{border: 0, borderRadius: 0, boxShadow: '0 0', background: 'transparent'}}>
             <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
             aria-controls="working-group-content"


### PR DESCRIPTION
Remove redundant `backgroundImage: none`, because `background: transparent` already removes background image