### PR TITLE
Release v0.14.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server 
-FROM docker.io/amvanbaren/openvsx-server:bcaf38c
+FROM ghcr.io/eclipse/openvsx-server:71941ca
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server 
-FROM docker.io/amvanbaren/openvsx-server:7ac79b5
+FROM ghcr.io/eclipse/openvsx-server:8e145b2
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN corepack enable
 RUN corepack prepare yarn@stable --activate
 
 # bump to update website
-ENV WEBSITE_VERSION 0.11.2
+ENV WEBSITE_VERSION 0.11.3
 COPY . /workdir
 
 RUN /usr/bin/yarn --cwd website \
@@ -27,7 +27,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server 
-FROM ghcr.io/eclipse/openvsx-server:8e145b2
+FROM ghcr.io/eclipse/openvsx-server:v0.14.5
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server 
-FROM ghcr.io/eclipse/openvsx-server:v0.14.4
+FROM docker.io/amvanbaren/openvsx-server:7ac79b5
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server 
-FROM ghcr.io/eclipse/openvsx-server:71941ca
+FROM ghcr.io/eclipse/openvsx-server:v0.14.4
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/ config/

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -75,7 +75,7 @@ management:
           - prometheus
   tracing:
     sampling:
-      probability: 1.0 # TODO lower to 0.1 for production
+      probability: 0.1
 org:
   jobrunr:
     job-scheduler:

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -157,7 +157,6 @@ ovsx:
     require-license: true
   elasticsearch:
     enabled: true
-    clear-on-start: true
     ssl: true
     relevance:
       rating: 0.2

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -157,6 +157,7 @@ ovsx:
     require-license: true
   elasticsearch:
     enabled: true
+    clear-on-start: true
     ssl: true
     relevance:
       rating: 0.2

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
     "repository": "https://github.com/eclipse/open-vsx.org",
     "license": "EPL-2.0",
     "dependencies": {
-        "openvsx-webui": "0.11.2"
+        "openvsx-webui": "0.11.3"
     },
     "peerDependencies": {
         "@babel/core": "^7.0.0"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2281,7 +2281,7 @@ __metadata:
     "@types/react-router-dom": "npm:^5.3.3"
     css-loader: "npm:^6.8.1"
     express: "npm:^4.18.2"
-    openvsx-webui: "npm:0.11.2"
+    openvsx-webui: "npm:0.11.3"
     source-map-loader: "npm:^4.0.1"
     style-loader: "npm:^3.3.3"
     typescript: "npm:~5.1.6"
@@ -2302,9 +2302,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openvsx-webui@npm:0.11.2":
-  version: 0.11.2
-  resolution: "openvsx-webui@npm:0.11.2"
+"openvsx-webui@npm:0.11.3":
+  version: 0.11.3
+  resolution: "openvsx-webui@npm:0.11.3"
   dependencies:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
@@ -2330,7 +2330,7 @@ __metadata:
     react-router-dom: "npm:^6.14.1"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: bcad7f4761e62f9060db49547d5dd1b4f00d619db907946622857c552772040dad39449b879b93fe27f592d921c56af4a6509d58881f21dcb68ef10044267de1
+  checksum: a9722040fbd8eea6063820e46424554def1680c0d4c0c2de2653ce09a110214b1ba5971d4e912070da0ae5a6c8b33c568fc4d4126f839309285410acedc0f73e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What's changed?
- https://github.com/eclipse/openvsx/pull/861
- https://github.com/eclipse/openvsx/pull/872
- https://github.com/eclipse/openvsx/pull/873
- https://github.com/eclipse/openvsx/pull/874
- Update `webui` to version 0.11.3
- Disable `ovsx.elasticsearch.clear-on-start` property