### PR TITLE
Release v0.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=4fc1c6da
+ARG SERVER_VERSION=v0.16.0
 
 # Builder image to compile the website
 FROM ubuntu as builder
@@ -29,8 +29,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-# FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
-FROM docker.io/amvanbaren/openvsx-server:${SERVER_VERSION}
+FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
 ARG SERVER_VERSION
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=04c8c4bf
+ARG SERVER_VERSION=v0.16.1
 
 # Builder image to compile the website
 FROM ubuntu as builder
@@ -29,8 +29,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-# FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
-FROM docker.io/amvanbaren/openvsx-server:${SERVER_VERSION}
+FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
 ARG SERVER_VERSION
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=v0.16.0
+ARG SERVER_VERSION=04c8c4bf
 
 # Builder image to compile the website
 FROM ubuntu as builder
@@ -29,7 +29,8 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
+# FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
+FROM docker.io/amvanbaren/openvsx-server:${SERVER_VERSION}
 ARG SERVER_VERSION
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=v0.16.0
+ARG SERVER_VERSION=4fc1c6da
 
 # Builder image to compile the website
 FROM ubuntu as builder
@@ -29,7 +29,8 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
+# FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
+FROM docker.io/amvanbaren/openvsx-server:${SERVER_VERSION}
 ARG SERVER_VERSION
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=v0.16.1
+ARG SERVER_VERSION=8383f5e3
 
 # Builder image to compile the website
 FROM ubuntu as builder
@@ -29,7 +29,8 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
+# FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
+FROM docker.io/amvanbaren/openvsx-server:${SERVER_VERSION}
 ARG SERVER_VERSION
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=54bc7b4e
+ARG SERVER_VERSION=v0.16.0
 
 # Builder image to compile the website
 FROM ubuntu as builder
@@ -29,7 +29,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM docker.io/amvanbaren/openvsx-server:${SERVER_VERSION}
+FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
 ARG SERVER_VERSION
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=8383f5e3
+ARG SERVER_VERSION=v0.16.1
 
 # Builder image to compile the website
 FROM ubuntu as builder
@@ -29,8 +29,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-# FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
-FROM docker.io/amvanbaren/openvsx-server:${SERVER_VERSION}
+FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
 ARG SERVER_VERSION
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -16,7 +16,7 @@ server:
     min-response-size: 1024
   jetty:
     threads:
-      max-queue-capacity: 100
+      max-queue-capacity: 200
 spring:
   application:
     name: openvsx-server

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -17,6 +17,7 @@ server:
   jetty:
     threads:
       max-queue-capacity: 200
+    connection-idle-timeout: 10000
 spring:
   application:
     name: openvsx-server

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -16,7 +16,7 @@ server:
     min-response-size: 1024
   jetty:
     threads:
-      max-queue-capacity: 200
+      max-queue-capacity: 100
     connection-idle-timeout: 10000
 spring:
   application:


### PR DESCRIPTION
Update the server to Spring Boot 3.2.2, to be able to configure connection timeout.
Set connection timeout to 10 seconds, so that it matches the proxy.
Lower queue capacity, because it doesn't seem to make a difference in request throughput.