### PR TITLE
Release v0.23.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=81fdb12e
+ARG SERVER_VERSION=f70f0a95
 
 # Builder image to compile the website
 FROM ubuntu AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=f70f0a95
+ARG SERVER_VERSION=v0.23.3
 
 # Builder image to compile the website
 FROM ubuntu AS builder
@@ -27,8 +27,7 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-# FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
-FROM docker.io/amvanbaren/openvsx-server:${SERVER_VERSION}
+FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
 ARG SERVER_VERSION
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=400a12b
+ARG SERVER_VERSION=v0.23.4
 
 # Builder image to compile the website
 FROM ubuntu AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=v0.23.3
+ARG SERVER_VERSION=400a12b
 
 # Builder image to compile the website
 FROM ubuntu AS builder

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -181,7 +181,7 @@ ovsx:
       timestamp: 1.2
   migrations:
     delay:
-      seconds: 300
+      seconds: 10800
   extension-control:
     update-on-start: true
   integrity:

--- a/website/src/menu-content.tsx
+++ b/website/src/menu-content.tsx
@@ -194,9 +194,6 @@ export const DefaultMenuContent: FunctionComponent = () => {
         <MenuRouteLink to='/about'>
             About
         </MenuRouteLink>
-        <Button variant='contained' color='secondary' href='/user-settings/extensions' sx={{ mx: 2.5 }}>
-            Publish
-        </Button>
         {loginProviders && (
             <>
                 <Button variant='contained' color='secondary' href='/user-settings/extensions' sx={{ mx: 2.5 }}>


### PR DESCRIPTION
## What's Changed
- https://github.com/eclipse/openvsx/pull/1147
- Delete duplicate publish button
- Increase migration delay to 3 hours, so that all queued jobs can be deleted before migration run.