### PR TITLE
Switch authentication from current OAuth to use Keycloak

### DIFF
--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -59,12 +59,8 @@ spring:
             scope: openvsx_publisher_agreement, profile
         provider:
           eclipse:
-            authorization-uri: https://accounts.eclipse.org/oauth2/authorize
-            token-uri: https://accounts.eclipse.org/oauth2/token
-            user-info-uri: https://accounts.eclipse.org/oauth2/UserInfo
-            user-name-attribute: name
-            user-info-authentication-method: header
-
+            issuer-uri: https://auth-staging.eclipse.org/realms/community-staging
+            user-name-attribute: preferred_username
 management:
   server:
     port: 8081


### PR DESCRIPTION
Hi @amvanbaren,

As discussed in [this comment](https://github.com/eclipse/openvsx/issues/1139#issuecomment-2938938538), I’ve created an MR to help move the project forward and unblock progress.

Please note that the MR is currently configured to use our staging Keycloak instance. Once you and @autumnfound have tested and confirmed everything is working, we’ll need to update it to point to the production realm for production:
https://auth.eclipse.org/realms/community

Martin will share the client ID and secret with you soon so you can finish the setup.

Thanks again for your support! I’ll let you and @autumnfound take it from here to finalize the integration. Let me know if anything else is needed on my end.

@amvanbaren @autumnfound - If changes are needed to my pull request, please feel free to edit it. 