### PR TITLE
Add email contact information.

### DIFF
--- a/website/src/about.tsx
+++ b/website/src/about.tsx
@@ -43,6 +43,12 @@ const About = () => {
 
         <Heading variant='h5'>Contact Us</Heading>
         <Paragraph variant='body1'>
+            To report malicious extensions, extensions with known vulnerabilities, or other urgent matters, connect with us via 
+            <Link color='secondary' underline='hover' href='mailto:marketplace@eclipse-foundation.org'>marketplace@eclipse-foundation.org</Link>.
+            For non-urgent matters, including managing namespaces or questions about publishing extensions, please visit the 
+            <Link color='secondary' underline='hover' href='https://github.com/EclipseFdn/open-vsx.org/wiki'>wiki</Link>
+        </Paragraph>
+        <Paragraph variant='body1'>
         We use Slack for instant messaging and general communication, 
         use this <Link color='secondary' underline='hover' href='https://join.slack.com/t/openvsxworkinggroup/shared_invite/zt-2y07y1ggy-ct3IfJljjGI6xWUQ9llv6A'>link</Link> to join our Slack workspace.
         </Paragraph>


### PR DESCRIPTION
This patch adds a pointer to the marketplace@eclipse-foundation.org inbox.

I don't have a means of testing this, so I'm only mostly sure that it's correct. This is further complicated by the fact that I am unfamiliar with the specific details of the markup language used, so I've made what I believe are really good guesses at what should be there. 

Please test this before merging.