### PR TITLE
Improve Grafana configuration

### DIFF
--- a/charts/openvsx/templates/grafana-alloy.yaml
+++ b/charts/openvsx/templates/grafana-alloy.yaml
@@ -51,6 +51,7 @@ data:
 
     prometheus.scrape "redis_scrape_{{ $index }}" {
       targets    = prometheus.exporter.redis.redis_metrics_{{ $index }}.targets
+      scrape_interval = "600s"
       forward_to = [prometheus.remote_write.default.receiver]
     }
 

--- a/charts/openvsx/templates/service-monitor.yaml
+++ b/charts/openvsx/templates/service-monitor.yaml
@@ -16,6 +16,6 @@ spec:
     matchNames:
       - {{ .Values.namespace }}
   endpoints:
-    - port: http
+    - port: management
       path: /actuator/prometheus
-      interval: 15s
+      interval: 60s


### PR DESCRIPTION
- Use the management port to collect Spring Boot metrics.
- Lower the scrape interval to once every 10 minutes. We went way over the metrics budget in a matter of days.