### PR TITLE
Add alloy nodeSelector for daemonst

### DIFF
--- a/charts/openvsx/values-staging.yaml
+++ b/charts/openvsx/values-staging.yaml
@@ -89,5 +89,7 @@ alloy:
     podLabels:
       app: *name
       environment: *environment
+    nodeSelector:
+      openvsx-staging-alloy: "true"
   fullnameOverride: grafana-alloy-staging
   namespaceOverride: *namespace

--- a/charts/openvsx/values.yaml
+++ b/charts/openvsx/values.yaml
@@ -89,5 +89,7 @@ alloy:
     podLabels:
       app: *name
       environment: *environment
+    nodeSelector:
+      openvsx-production-alloy: "true"
   fullnameOverride: grafana-alloy-production
   namespaceOverride: *namespace


### PR DESCRIPTION
Adding nodeSelector in order to limit number of alloy instances on cluster.