### PR TITLE
Add version and update date to publisher agreement markdown file

### DIFF
--- a/website/static/documents/publisher-agreement-v1.1.md
+++ b/website/static/documents/publisher-agreement-v1.1.md
@@ -2,6 +2,8 @@
 
 # Open VSX Publisher Agreement
 
+Version 1.1 – September 2025  
+
 Thank you for your interest in publishing in the Eclipse Open VSX Registry (“Open VSX”). As used in this Eclipse Open VSX Publisher Agreement (“Agreement”), the term “you”, ”your” or “publisher” refers to you as an individual, and, to the extent you are the agent or employee of another person or entity (such person or entity, a “Principal”) “you” and “publisher” also includes that Principal.  
 
 This Agreement describes the relationship between you and the Eclipse Foundation AISBL, a Belgian international not-for-profit association (AISBL/IVZW) incorporated under the laws of Belgium as well as its Affiliates (as defined herein) (collectively, “Eclipse,” “us” or “we”) and governs your publication of any Offering (as defined below) within the Registry (as defined below).  


### PR DESCRIPTION
To add content included in document footers for context to the document, the version and update date (year and month) have been added at the top of the markdown file.

Additionally, increments the site version as this should be immediately released.