### PR TITLE
Fix: correct URL for open-vsx.org maintenance status

### DIFF
--- a/website/src/page-settings.tsx
+++ b/website/src/page-settings.tsx
@@ -133,7 +133,7 @@ export default function createPageSettings(theme: Theme, prefersDarkMode: boolea
                 <InfoIcon fontSize='large' />
             </Box>
             <Typography variant='body1'>
-                Open VSX will be migrating storage infrastructure on <Typography variant='body1' component='span' sx={{ fontWeight: 'bold' }}>Thursday, November 27, 2025 at 9:00 AM ET</Typography>. The registry will be in read-only mode during the migration – <Link color='secondary' underline='hover' href='https://www.eclipsestatus.io/maintenance' target='_blank' rel='noopener'>More details</Link>.
+                Open VSX will be migrating storage infrastructure on <Typography variant='body1' component='span' sx={{ fontWeight: 'bold' }}>Thursday, November 27, 2025 at 9:00 AM ET</Typography>. The registry will be in read-only mode during the migration – <Link color='secondary' underline='hover' href='https://status.open-vsx.org/maintenance' target='_blank' rel='noopener'>More details</Link>.
             </Typography>
         </Box>;
 


### PR DESCRIPTION
The banner did have a wrong link, it was pointing to eclipsestatus.io instead of status.open-vsx.org