### PR TITLE
Deploy v0.29.1 migration to production in preparation for storage migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG SERVER_VERSION=v0.29.1
+ARG SERVER_VERSION=ec88d06
+ARG SERVER_VERSION_STRING=v0.29.1-migration
 
 # Builder image to compile the website
 FROM ubuntu AS builder
@@ -27,12 +28,13 @@ RUN /usr/bin/yarn --cwd website \
   && /usr/bin/yarn --cwd website build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse/openvsx-server:${SERVER_VERSION}
+FROM ghcr.io/netomi/openvsx-server:${SERVER_VERSION}
 ARG SERVER_VERSION
+ARG SERVER_VERSION_STRING
 
 COPY --from=builder --chown=openvsx:openvsx /workdir/website/static/ BOOT-INF/classes/static/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/application.yml config/
 COPY --from=builder --chown=openvsx:openvsx /workdir/configuration/logback-spring.xml BOOT-INF/classes/
 
 # Replace version placeholder with arg value
-RUN sed -i "s/<SERVER_VERSION>/$SERVER_VERSION/g" config/application.yml
+RUN sed -i "s/<SERVER_VERSION>/${SERVER_VERSION_STRING}/g" config/application.yml

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -159,6 +159,9 @@ ovsx:
   token-prefix: ovsxp_
   storage:
     primary-service: azure-blob
+    download-counts: false  # disable inefficient download count mechanism for anything other than azure
+    migration:
+      enabled: false  # disable automatic storage migration when we switch the primary-service
   webui:
     frontendRoutes: "/extension/**,/namespace/**,/user-settings/**,/admin-dashboard/**,/about,/publisher-agreement-*,/terms-of-use,/members,/adopters,/error"
   eclipse:


### PR DESCRIPTION
This PR deploys v0.29.1-migration to production which we tested on staging to do the migration.

It is based on v0.29.1 with some changes required to support the migration, see https://github.com/netomi/openvsx/pull/2 for a list of changes.

The configuration includes the following changes:

 - disable automatic storage migration as it will be done manually
 - disable download count mechanism for any storage type other than azure as it will be too inefficient