### PR TITLE
Update to fixed image of netomi/openvsx-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SERVER_VERSION=ec88d06
+ARG SERVER_VERSION=c1e63f7
 ARG SERVER_VERSION_STRING=v0.29.1-migration
 
 # Builder image to compile the website


### PR DESCRIPTION
This PR fixes the used image for production.

The docker image was built with openvsx@master as base ref thus also including recent code changes that should not be included. I rebuild the image with openvsx@0.29.1 as base ref and verified that the content is correct.