### PR TITLE
Enable cloudfront again (via redirect from openvsx.eclipsecontent.org)

### DIFF
--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -161,7 +161,7 @@ ovsx:
     primary-service: aws
     cdn:
       storage-filter: ".*AwsStorageService.*"
-      prefix-url: http://openvsx.eclipsecontent.org
+      prefix-url: https://openvsx.eclipsecontent.org
     download-counts: false  # disable inefficient download count mechanism for anything other than azure
     migration:
       enabled: false  # disable automatic storage migration when we switch the primary-service


### PR DESCRIPTION
We ran the production cloudfront CDN URL on the staging instance since yesterday (staging.open-vsx.org). Everything looks good and no errors are visible, so we should be fine to enable that config as well on production.