### PR TITLE
Exclude production branch from scorecard analysis

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - main
-    - production
   schedule:
     # Weekly on Saturdays.
     - cron:  '30 1 * * 6'


### PR DESCRIPTION
This change was missing in the last PR.

scorecard only works on the default branch and it also does not make sense to run it on production.