### PR TITLE
Add 'include-stacktrace' configuration option

### DIFF
--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -14,6 +14,7 @@ server:
     path: /server-error
     whitelabel:
       enabled: false
+    include-stacktrace: never
   compression:
     enabled: true
     mime-types: text/html,text/plain,text/css,application/javascript,application/json,text/xml,application/xml,application/xml+rss,text/javascript


### PR DESCRIPTION
This change prevents the inclusion of stacktraces when an error page is returned.