### PR TITLE
Deploy 0.32.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG SERVER_VERSION=v0.32.2
-ARG SERVER_VERSION_STRING=v0.32.2
+ARG SERVER_VERSION=v0.32.3
+ARG SERVER_VERSION_STRING=v0.32.3
 
 # Builder image to compile the website
 FROM ubuntu:24.04 AS builder


### PR DESCRIPTION
This PR deploys 0.32.3, which includes 3 small bugfixes:

* Improve error handling in VSCodeAPI wrt file resources by @netomi in https://github.com/eclipse/openvsx/pull/1625
* Check if the IP address string can be resolved to an IPv4 address by @netomi in https://github.com/eclipse/openvsx/pull/1627
* Ensure temporary extension files are deleted during publication by @netomi in https://github.com/eclipse/openvsx/pull/1628
