### PR TITLE
feat: add HPA-based pod autoscaling to okd deployments

### DIFF
--- a/charts/openvsx/templates/deployment.yaml
+++ b/charts/openvsx/templates/deployment.yaml
@@ -9,7 +9,9 @@ metadata:
 spec:
   progressDeadlineSeconds: 3600
   revisionHistoryLimit: 1
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.name }}

--- a/charts/openvsx/templates/okd-hpa.yaml
+++ b/charts/openvsx/templates/okd-hpa.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}-{{ .Values.environment }}-{{ .Values.platform }}-hpa
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+    environment: {{ .Values.environment }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}-{{ .Values.environment }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleDown:
+      # Look at the last N minutes and pick the HIGHEST replica count recommended.
+      # This ensures we don't scale down during a brief dip in traffic.
+      stabilizationWindowSeconds: {{ .Values.autoscaling.scaleDownWindow | default 600 }}
+      policies:
+      - type: Percent
+        value: 10
+        periodSeconds: 60  # Only remove 10% of pods per minute
+    scaleUp:
+      # Scale up almost immediately to handle spikes quickly.
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 15  # Double the fleet size every 15s if needed
+{{- end }}

--- a/charts/openvsx/values-staging.yaml
+++ b/charts/openvsx/values-staging.yaml
@@ -4,9 +4,18 @@ name: &name open-vsx-org
 environment: &environment staging
 namespace: &namespace open-vsx-org-staging
 host: staging.open-vsx.org
+platform: okd
 
 replicaCount: 1
 esReplicaCount: 1
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+  scaleDownWindow: 300
 
 image:
   repository: ghcr.io/eclipsefdn/openvsx-website

--- a/charts/openvsx/values-test.yaml
+++ b/charts/openvsx/values-test.yaml
@@ -4,9 +4,13 @@ name: &name open-vsx-org
 environment: &environment test
 namespace: &namespace open-vsx-org-test
 host: test.open-vsx.org
+platform: okd
 
 replicaCount: 1
 esReplicaCount: 1
+
+autoscaling:
+  enabled: false
 
 image:
   repository: ghcr.io/eclipsefdn/openvsx-website

--- a/charts/openvsx/values.yaml
+++ b/charts/openvsx/values.yaml
@@ -4,9 +4,18 @@ name: &name open-vsx-org
 environment: &environment production
 namespace: &namespace open-vsx-org
 host: open-vsx.org
+platform: okd
 
 replicaCount: 6
 esReplicaCount: 3
+
+autoscaling:
+  enabled: false
+  # minReplicas: 6
+  # maxReplicas: 12
+  # targetCPUUtilizationPercentage: 70
+  # targetMemoryUtilizationPercentage: 80
+  # scaleDownWindow: 600
 
 image:
   repository: ghcr.io/eclipsefdn/openvsx-website


### PR DESCRIPTION
**Summary of Changes:**

1. Adds a HorizontalPodAutoscaler Helm template using autoscaling/v2, enabling CPU and memory-based pod autoscaling for the openvsx deployment
2. Introduces a platform value to the values files so HPA resources are named unambiguously (e.g. open-vsx-org-staging-okd-hpa) and future EKS autoscaling can coexist without naming conflicts
3. Conditionally omits replicas from the Deployment spec when autoscaling is enabled, preventing Helm upgrades from overriding the replica count managed by the HPA
4. Autoscaling is enabled on staging (1–3 replicas) as a low-risk pilot, and disabled on production and test 

**Autoscaling behaviour**

Scale-up: Reacts immediately  doubling fleet size every 15s to absorb traffic spikes quickly.
Scale-down: Conservative — uses a scaleDownWindow stabilisation window and removes at most 10% of pods per minute, preventing flapping on brief traffic dips.
Triggers: CPU ≥ 70% or memory ≥ 80% average utilization across pods.