### PR TITLE
Enhance logging and rate limiting configurations

### DIFF
--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -155,7 +155,7 @@ ovsx:
       seconds: 10800
     once-per-version: true
   extension-control:
-    update-on-start: true
+    update-on-start: false
   integrity:
     key-pair: create
   registry:


### PR DESCRIPTION
This PR does 2 configuration changes (currently running on staging):

 - reduce log verbosity for redis connection watchdog
 - change the function to get the IP address from a request

Using the header "X-Real-IP" is the default, which is set by nginx for all requests, however some internal requests from openshift hit the application as well, and I need to understand what they are.

Could not reproduce that on staging, so updating the configuration on production.