### PR TITLE
Add Argus scanning service

### DIFF
--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -354,13 +354,19 @@ ovsx:
         enforced: true
         async: true        # Asynchronous - POST returns a jobId, then poll until done
         timeout-minutes: 30
+        max-concurrent-scans: 40
+
+        # Deep-link template for the admin scan dashboard. {jobId} is replaced
+        # with the scanner's externalJobId at render time, giving admins a
+        # clickable link from a scan check result to Argus's own UI.
+        external-url-template: "https://app.yeethsecurity.com/dashboard/scans/{jobId}"
 
         http:
           max-total: 20
           default-max-per-route: 10
-          connection-request-timeout-ms: 60000   # Time to get connection from pool (1 min)
-          connect-timeout-ms: 60000              # Time to establish TCP connection (1 min)
-          socket-timeout-ms: 60000               # Short - start call only returns jobId, not results
+          connection-request-timeout-ms: 60000
+          connect-timeout-ms: 60000
+          socket-timeout-ms: 300000   # 5 min for large extensions
 
         start:
           method: POST
@@ -404,6 +410,7 @@ ovsx:
               name-path: "$.rule"
               description-path: "$.details"
               severity-path: "$.severity"
+              file-path-path: "$.fileName"
               file-hash-path: "$.fileHash"
 
         polling:

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -343,3 +343,70 @@ ovsx:
               file-hash-path: "$.file_hash"
               description-path: "$.description"
               severity-path: "$.severity"
+
+      # Argus Scanner - cloud-based multi-engine malware and AI analysis service
+      # API: POST /api/scan to start, GET /api/scan/{jobId} to poll for completion.
+      # Requires an Argus API key set as a Bearer token (set ARGUS_API_KEY env var).
+      argus:
+        enabled: true
+        type: "ARGUS"
+        required: false
+        enforced: true
+        async: true        # Asynchronous - POST returns a jobId, then poll until done
+        timeout-minutes: 30
+
+        http:
+          max-total: 20
+          default-max-per-route: 10
+          connection-request-timeout-ms: 60000   # Time to get connection from pool (1 min)
+          connect-timeout-ms: 60000              # Time to establish TCP connection (1 min)
+          socket-timeout-ms: 60000               # Short - start call only returns jobId, not results
+
+        start:
+          method: POST
+          url: "https://api.yeethsecurity.com/api/scan"
+          headers:
+            Accept: "application/json"
+            Authorization: "Bearer ${ARGUS_API_KEY}"
+          body:
+            type: multipart
+            file-field: "file"
+          response:
+            format: json
+            job-id-path: "$.jobId"  # Extract jobId for use in poll/result URLs
+
+        poll:
+          method: GET
+          url: "https://api.yeethsecurity.com/api/scan/{jobId}"  # {jobId} substituted at runtime
+          headers:
+            Accept: "application/json"
+            Authorization: "Bearer ${ARGUS_API_KEY}"
+          response:
+            format: json
+            status-path: "$.status"
+            status-mapping:
+              queued: SUBMITTED
+              scanning: PROCESSING
+              completed: COMPLETED
+              error: FAILED
+
+        result:
+          method: GET
+          url: "https://api.yeethsecurity.com/api/scan/{jobId}"
+          headers:
+            Accept: "application/json"
+            Authorization: "Bearer ${ARGUS_API_KEY}"
+          response:
+            format: json
+            threats-path: "$.matches[*]"
+            threat-mapping:
+              condition: "true"
+              name-path: "$.rule"
+              description-path: "$.details"
+              severity-path: "$.severity"
+              file-hash-path: "$.fileHash"
+
+        polling:
+          initial-delay-seconds: 10
+          interval-seconds: 15
+          max-attempts: 120

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -354,7 +354,7 @@ ovsx:
         enforced: true
         async: true        # Asynchronous - POST returns a jobId, then poll until done
         timeout-minutes: 30
-        max-concurrent-scans: 40
+        max-concurrency: 40
 
         # Deep-link template for the admin scan dashboard. {jobId} is replaced
         # with the scanner's externalJobId at render time, giving admins a


### PR DESCRIPTION
This PR adds support for Argus as a pre-publish malware scanning backend in the Open VSX registry as part of the work agreed upon by the Eclipse Foundation.

Argus is a cloud-based multi-engine malware and AI analysis service exposed through https://app.yeethsecurity.com / https://api.yeethsecurity.com. The integration follows Argus’s asynchronous scan flow:

- POST /api/scan uploads the extension package and returns a jobId
- GET /api/scan/{jobId} is used to poll scan status until completion
- the same result endpoint is then parsed for findings

The scanner is wired into the existing configurable scanner framework and maps Argus responses into the registry’s standard scan result model.

### Configuration added
This change introduces an argus scanner definition with the following behavior:

- enabled: true
- type: "ARGUS"
- required: false
- enforced: true
- async: true
- timeout-minutes: 30

### Why
This strengthens pre-publish security checks by adding another detection layer for malicious extensions. Argus complements the existing checks by providing cloud-based multi-engine and AI-assisted analysis, while fitting the same enforcement model already being introduced for other scanners.

The 30-minute timeout is deliberately set as larger buffer. This provides enough headroom for additional detection stages and future detection enhancements.

### Implementation details

- Adds a new scanner configuration block for ARGUS
- Supports asynchronous execution with job-based polling
- Uses the standard HTTP client settings and timeout controls
- Normalizes Argus findings into the common threat model used by the registry
- Keeps the scanner enforced but not required initially, which matches the cautious rollout pattern discussed for other checks

### Operational notes

- Requires ARGUS_API_KEY to be present in the environment
- Depending on network management of the production environment, there may be a change required to the egress rules to allow the server to reach Argus services
- Because this scanner is asynchronous and network-dependent, it is introduced as:
  - enforced: true so detected threats can block publication
  - required: false so transient scanner availability issues do not immediately cause unnecessary publishing failures
- Once stability and reliability are proven in production, required can be reconsidered

@chrisguindon @netomi 