### PR TITLE
feat: route loki4j logs through Grafana Alloy

### DIFF
--- a/charts/openvsx/templates/grafana-alloy.yaml
+++ b/charts/openvsx/templates/grafana-alloy.yaml
@@ -68,6 +68,40 @@ data:
       }
     }
 
+    loki.source.api "loki_push" {
+      http {
+        listen_address = "0.0.0.0"
+        listen_port    = 3100
+      }
+      forward_to = [loki.relabel.add_labels.receiver]
+    }
+
+    loki.relabel "add_labels" {
+      rule {
+        target_label = "environment"
+        replacement  = "{{ .Values.environment }}"
+      }
+      rule {
+        target_label = "cluster"
+        replacement  = "{{ .Values.platform }}"
+      }
+      forward_to = [loki.write.grafana_cloud.receiver]
+    }
+
+    loki.write "grafana_cloud" {
+      endpoint {
+        url = sys.env("LOKI_URL")
+        basic_auth {
+          username = sys.env("LOKI_USERNAME")
+          password = sys.env("LOKI_PASSWORD")
+        }
+      }
+      external_labels = {
+        cluster  = "{{ .Values.environment }}-{{ .Values.platform }}",
+        platform = "{{ .Values.platform }}",
+      }
+    }
+
     otelcol.receiver.zipkin "default" {
       endpoint = "0.0.0.0:9411"
       output {

--- a/charts/openvsx/values-staging.yaml
+++ b/charts/openvsx/values-staging.yaml
@@ -2,6 +2,7 @@
 
 name: &name open-vsx-org
 environment: &environment staging
+platform: &platform okd-c1
 namespace: &namespace open-vsx-org-staging
 host: staging.open-vsx.org
 

--- a/charts/openvsx/values-test.yaml
+++ b/charts/openvsx/values-test.yaml
@@ -2,6 +2,7 @@
 
 name: &name open-vsx-org
 environment: &environment test
+platform: &platform okd-c1
 namespace: &namespace open-vsx-org-test
 host: test.open-vsx.org
 

--- a/charts/openvsx/values.yaml
+++ b/charts/openvsx/values.yaml
@@ -2,6 +2,7 @@
 
 name: &name open-vsx-org
 environment: &environment production
+platform: &platform okd-c1
 namespace: &namespace open-vsx-org
 host: open-vsx.org
 
@@ -100,6 +101,9 @@ alloy:
       - name: zipkin
         port: 9411
         targetPort: 9411
+      - name: loki
+        port: 3100
+        targetPort: 3100
   crds:
     create: true
   controller:

--- a/configuration/logback-spring.xml
+++ b/configuration/logback-spring.xml
@@ -7,11 +7,7 @@
         <verbose>true</verbose>
         <batchMaxBytes>65536</batchMaxBytes>
         <http>
-            <url>${LOKI_URL}</url>
-            <auth>
-                <username>${LOKI_USERNAME}</username>
-                <password>${LOKI_PASSWORD}</password>
-            </auth>
+            <url>http://grafana-alloy-${ENVNAME}:3100/loki/api/v1/push</url>
             <requestTimeoutMs>15000</requestTimeoutMs>
         </http>
         <format>


### PR DESCRIPTION
- Add loki.source.api on port 3100 to receive logs from loki4j
- Add loki.relabel to attach environment and cluster labels
- Add loki.write to forward logs to Grafana Cloud with external_labels: cluster  = '<environment>-<platform>' platform = '<platform>'
- Expose port 3100 on Alloy pod/service
- Add platform: okd-c1 to all values files (production, staging, test)
- Update logback-spring.xml to push logs to local Alloy without auth (http://grafana-alloy-${ENVNAME}:3100/loki/api/v1/push)

EF issue: https://gitlab.eclipse.org/eclipsefdn/infrazilla/-/issues/2706