### PR TITLE
feat:

### DIFF
--- a/charts/openvsx/templates/grafana-alloy.yaml
+++ b/charts/openvsx/templates/grafana-alloy.yaml
@@ -33,7 +33,7 @@ data:
       }
 
       rule {
-        regex   = "^(exported_instance|deployment_environment|service_instance_id|service_name)$"
+        regex   = "^(exported_instance|deployment_environment|service_instance_id)$"
         action  = "labeldrop"
       }
 
@@ -57,6 +57,10 @@ data:
 
     {{- end }}
     prometheus.remote_write "default" {
+      external_labels = {
+        cluster  = "{{ .Values.environment }}-{{ .Values.platform }}",
+        platform = "{{ .Values.platform }}",
+      }
       endpoint {
         name = "hosted-prometheus"
         url = sys.env("PROMETHEUS_URL")
@@ -85,6 +89,22 @@ data:
       check_interval = "1s"
       limit = "400MiB"
       spike_limit = "80MiB"
+      output {
+        traces = [otelcol.processor.resource.add_labels.input]
+      }
+    }
+
+    otelcol.processor.resource "add_labels" {
+      attributes {
+        action = "upsert"
+        key    = "cluster"
+        value  = "{{ .Values.environment }}-{{ .Values.platform }}"
+      }
+      attributes {
+        action = "upsert"
+        key    = "environment"
+        value  = "{{ .Values.environment }}"
+      }
       output {
         traces = [otelcol.processor.batch.default.input]
       }

--- a/configuration/logback-spring.xml
+++ b/configuration/logback-spring.xml
@@ -16,7 +16,7 @@
         </http>
         <format>
             <label>
-                <pattern>job=loki4j,environment=${ENVNAME},instance=${HOSTNAME},application=${appName},traceID=%X{traceId:-NONE},level=%level</pattern>
+                <pattern>job=loki4j,environment=${ENVNAME},instance=${HOSTNAME},application=${appName},service_name=${appName},traceID=%X{traceId:-NONE},level=%level</pattern>
             </label>
             <message>
                 <pattern>${FILE_LOG_PATTERN}</pattern>


### PR DESCRIPTION
- Add external_labels (cluster, platform) to prometheus.remote_write so metrics carry the same cluster/platform labels as Loki logs
- Insert otelcol.processor.resource into the traces pipeline to stamp cluster and environment resource attributes on every span, enabling Grafana trace<->log/metric correlation
- Remove service_name from the Alloy labeldrop regex so the OTel-generated service_name label is retained on Prometheus metrics
- Add service_name label to the loki4j pattern in logback-spring.xml so Loki logs expose the same service_name value as metrics and traces