### PR TITLE
Add missing Loki pipeline and align with main branch

### DIFF
--- a/charts/openvsx/templates/grafana-alloy.yaml
+++ b/charts/openvsx/templates/grafana-alloy.yaml
@@ -78,6 +78,40 @@ data:
       }
     }
 
+    loki.source.api "loki_push" {
+      http {
+        listen_address = "0.0.0.0"
+        listen_port    = 3100
+      }
+      forward_to = [loki.relabel.add_labels.receiver]
+    }
+
+    loki.relabel "add_labels" {
+      rule {
+        target_label = "environment"
+        replacement  = "{{ .Values.environment }}"
+      }
+      rule {
+        target_label = "cluster"
+        replacement  = "{{ .Values.platform }}"
+      }
+      forward_to = [loki.write.grafana_cloud.receiver]
+    }
+
+    loki.write "grafana_cloud" {
+      endpoint {
+        url = sys.env("LOKI_URL")
+        basic_auth {
+          username = sys.env("LOKI_USERNAME")
+          password = sys.env("LOKI_PASSWORD")
+        }
+      }
+      external_labels = {
+        cluster  = "{{ .Values.environment }}-{{ .Values.platform }}",
+        platform = "{{ .Values.platform }}",
+      }
+    }
+
     otelcol.receiver.zipkin "default" {
       endpoint = "0.0.0.0:9411"
       output {

--- a/configuration/logback-spring.xml
+++ b/configuration/logback-spring.xml
@@ -7,11 +7,7 @@
         <verbose>true</verbose>
         <batchMaxBytes>65536</batchMaxBytes>
         <http>
-            <url>${LOKI_URL}</url>
-            <auth>
-                <username>${LOKI_USERNAME}</username>
-                <password>${LOKI_PASSWORD}</password>
-            </auth>
+            <url>http://grafana-alloy-${ENVNAME}:3100/loki/api/v1/push</url>
             <requestTimeoutMs>15000</requestTimeoutMs>
         </http>
         <format>


### PR DESCRIPTION
    - Add loki.source.api, loki.relabel and loki.write blocks to Alloy, matching main: receives logs on port 3100, stamps environment/cluster labels, forwards to Grafana Cloud with external_labels
    - Revert loki4j URL in logback-spring.xml to push through Alloy (http://grafana-alloy-:3100) instead of directly to Grafana Cloud, matching main branch behaviour