### PR TITLE
docs: revise security issue reporting instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,30 +1,34 @@
 # Security Policy
 
-This Eclipse Foundation Project adheres to the [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy/).
+## Reporting Security Issues
 
-## How To Report a Vulnerability
+If you believe you have found a security vulnerability affecting the deployment, configuration, infrastructure, integrations, or operation of the public Open VSX service at <https://open-vsx.org>, please report it through coordinated disclosure.
 
-If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
+**Do not report security vulnerabilities through public GitHub issues, discussions, pull requests, or other public channels.**
 
-**Please do not report security vulnerabilities through public issues, discussions, or change requests.**
+For security issues related to this repository, report the issue by email to:
 
-Instead, you can report it using one of the following ways:
+<security@open-vsx.org>
 
-* Contact the [Eclipse Foundation Security Team](mailto:security@eclipse-foundation.org) via email
-* Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+Reports concerning this repository are handled as security issues affecting the public Open VSX service, as described in section 4.2 of the [Open VSX Security Policy](https://researcher-recognition.open-vsx.org/open-vsx-security-policy/).
 
-You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
+## What To Include
 
-Please include as much of the information listed below as you can to help us better understand and resolve the issue:
+Please include as much relevant information as reasonably possible, such as:
 
-* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
-* Affected version(s)
-* Impact of the issue, including how an attacker might exploit the issue
-* Step-by-step instructions to reproduce the issue
-* The location of the affected source code (tag/branch/commit or direct URL)
-* Full paths of source file(s) related to the manifestation of the issue
-* Any special configuration required to reproduce the issue
-* Any log files that are related to this issue (if possible)
-* Proof-of-concept or exploit code (if possible)
+- A description of the issue;
+- The affected service area, component, configuration, URL, or workflow;
+- Steps to reproduce the issue, if applicable;
+- The observed or potential impact;
+- Relevant logs, screenshots, request/response details, or other supporting evidence;
+- Any proof-of-concept material, only where necessary and safe to provide.
 
-This information will help us triage your report more quickly.
+Please do not include credentials, secrets, personal data, confidential information, or production data unless it is strictly necessary to understand and investigate the issue.
+
+## Other Open VSX Security Reports
+
+For vulnerabilities in the Open VSX open source codebase, release artifacts, or project-maintained components outside this repository, follow the reporting instructions in the relevant Open VSX project security policy.
+
+For suspected malicious extensions, publisher abuse, namespace abuse, misleading extension listings, or other extension-related security or policy concerns, follow the reporting instructions in the [Open VSX Security Policy](https://researcher-recognition.open-vsx.org/open-vsx-security-policy/).
+
+If you are unsure how to classify a report, report it privately rather than publicly.


### PR DESCRIPTION
Updated the security reporting guidelines and added details on what to include when reporting vulnerabilities.