### PR TITLE
Update server version to v0.34.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG SERVER_VERSION=v0.34.4
-ARG SERVER_VERSION_STRING=v0.34.4
+ARG SERVER_VERSION=v0.34.5
+ARG SERVER_VERSION_STRING=v0.34.5
 
 # Builder image to compile the website
 FROM ubuntu:24.04 AS builder

--- a/charts/openvsx/templates/clamav-rest/pvc.yaml
+++ b/charts/openvsx/templates/clamav-rest/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clamav-db
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 2Gi


### PR DESCRIPTION
This PR deploys [0.34.5](https://github.com/eclipse-openvsx/openvsx/releases/tag/v0.34.5) to production.

It basically includes a fix for publication of extensions as a recently added check is too strict.