### PR TITLE
Update jetty configuration

### DIFF
--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -26,8 +26,9 @@ server:
     min-response-size: 1024
   jetty:
     threads:
-      max-queue-capacity: 100
-    connection-idle-timeout: 10000
+      max: 250
+      max-queue-capacity: 50
+    connection-idle-timeout: 65000
 spring:
   application:
     name: openvsx-server


### PR DESCRIPTION
This updates the jetty configuration for the open-vsx pods.

It aligns the connection timeout with the ones at fastly / nginx and bumps the number of max connections.