### PR TITLE
fix(aws-production): align with production branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG SERVER_VERSION=v0.34.5
-ARG SERVER_VERSION_STRING=v0.34.5
+ARG SERVER_VERSION=read-only-mode
+ARG SERVER_VERSION_STRING=v1.0.0-dev.rc.0
 
 # Builder image to compile the website
 FROM ubuntu:24.04 AS builder
@@ -27,7 +27,7 @@ RUN cd website \
   && yarn build
 
 # Main image derived from openvsx-server
-FROM ghcr.io/eclipse-openvsx/openvsx-server:${SERVER_VERSION}
+FROM ghcr.io/eclipse-openvsx/openvsx-server-snapshot:${SERVER_VERSION}
 ARG SERVER_VERSION
 ARG SERVER_VERSION_STRING
 

--- a/charts/openvsx/Chart.lock
+++ b/charts/openvsx/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: aws-load-balancer-controller
   repository: https://aws.github.io/eks-charts
   version: 1.14.0
-digest: sha256:e2c6dcf71280bba07adec1bf48d16ede03c8e30b5075a1899e460a6c393eaf16
-generated: "2026-03-21T12:01:49.110601-04:00"
+digest: sha256:b52c45774d933d827fe23462c0366dfff0fa34d7a79bda07da695aec6e5fb385
+generated: "2026-05-20T18:34:14.480292-04:00"

--- a/charts/openvsx/Chart.yaml
+++ b/charts/openvsx/Chart.yaml
@@ -12,8 +12,8 @@ dependencies:
   - name: postgresql-ha
     version: 16.3.2
     repository: https://charts.bitnami.com/bitnami
-    condition: eks.enabled
+    condition: postgresql-ha.enabled
   - name: aws-load-balancer-controller
     version: 1.14.0
     repository: https://aws.github.io/eks-charts
-    condition: eks.enabled
+    condition: aws-load-balancer-controller.enabled

--- a/charts/openvsx/templates/grafana-alloy.yaml
+++ b/charts/openvsx/templates/grafana-alloy.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.eks.enabled }}
+{{- if not (and .Values.eks.enabled (eq .Values.environment "production")) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/openvsx/templates/ingress.yaml
+++ b/charts/openvsx/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.eks.enabled }}
+{{- $preActions := .Values.ingress.preActions | default (list "ssl-redirect") }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -12,13 +13,15 @@ spec:
   - host: {{ .Values.host }}
     http:
       paths:
+      {{- range $action := $preActions }}
       - path: /
         pathType: Prefix
         backend:
           service:
-            name: {{ .Values.ingress.preActionName | default "ssl-redirect" }}
+            name: {{ $action }}
             port:
               name: use-annotation
+      {{- end }}
       - path: /
         pathType: Prefix
         backend:
@@ -30,13 +33,15 @@ spec:
   - host: www.{{ .Values.host }}
     http:
       paths:
+      {{- range $action := $preActions }}
       - path: /
         pathType: Prefix
         backend:
           service:
-            name: {{ .Values.ingress.preActionName | default "ssl-redirect" }}
+            name: {{ $action }}
             port:
               name: use-annotation
+      {{- end }}
       - path: /
         pathType: Prefix
         backend:

--- a/charts/openvsx/templates/ingress.yaml
+++ b/charts/openvsx/templates/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
+  ingressClassName: {{ .Values.ingress.className | default "alb" }}
   rules:
   - host: {{ .Values.host }}
     http:

--- a/charts/openvsx/templates/ingress.yaml
+++ b/charts/openvsx/templates/ingress.yaml
@@ -15,7 +15,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: ssl-redirect
+            name: {{ .Values.ingress.preActionName | default "ssl-redirect" }}
             port:
               name: use-annotation
       - path: /
@@ -33,7 +33,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: ssl-redirect
+            name: {{ .Values.ingress.preActionName | default "ssl-redirect" }}
             port:
               name: use-annotation
       - path: /

--- a/charts/openvsx/templates/redis-cluster-operator/deployment.yaml
+++ b/charts/openvsx/templates/redis-cluster-operator/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.eks.enabled }}
+{{- if not (and .Values.eks.enabled (eq .Values.environment "production")) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/openvsx/templates/redis-cluster-operator/rbac.yaml
+++ b/charts/openvsx/templates/redis-cluster-operator/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.eks.enabled }}
+{{- if not (and .Values.eks.enabled (eq .Values.environment "production")) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/openvsx/templates/redis-cluster.yaml
+++ b/charts/openvsx/templates/redis-cluster.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.eks.enabled }}
+{{- if not (and .Values.eks.enabled (eq .Values.environment "production")) }}
 apiVersion: open-vsx.org/v1
 kind: RedisCluster
 metadata:

--- a/charts/openvsx/templates/scaledobject.yaml
+++ b/charts/openvsx/templates/scaledobject.yaml
@@ -27,35 +27,25 @@ spec:
               value: {{ .Values.keda.scaleDown.pods | default 1 }}
               periodSeconds: {{ .Values.keda.scaleDown.periodSeconds | default 180 }}
   triggers:
-  # Filter on environment (set by the app via management.metrics.tags) rather than namespace,
-  # which only exists if Alloy injects it at scrape time -> survives scrape-config changes.
+  # Single signal: avg pod busy/max ratio, smoothed over 5m. Self-normalizing
+  # across jetty.threads.max changes — threshold stays valid at any cap.
+  # Filter on the environment label (set by management.metrics.tags) so this
+  # survives Alloy scrape-config changes that may or may not inject namespace.
   - type: prometheus
     metadata:
       serverAddress: {{ .Values.keda.prometheusAddress }}
-      metricName: jetty_threads_busy_total
-      # 150 = 75% of Jetty's 200-thread max; scale when avg busy threads per replica exceeds this.
-      threshold: "150"
-      query: sum(jetty_threads_busy{environment="{{ .Values.environment }}",application="openvsx-server"})
-      authModes: "basic"
-    authenticationRef:
-      name: {{ .Values.name }}-grafana-cloud-auth
-  - type: prometheus
-    metadata:
-      serverAddress: {{ .Values.keda.prometheusAddress }}
-      metricName: jetty_threads_queued_total
-      # Any sustained queue depth means the thread pool is saturated; scale aggressively.
-      threshold: "20"
-      query: sum(jetty_threads_jobs{environment="{{ .Values.environment }}",application="openvsx-server"})
-      authModes: "basic"
-    authenticationRef:
-      name: {{ .Values.name }}-grafana-cloud-auth
-  - type: prometheus
-    metadata:
-      serverAddress: {{ .Values.keda.prometheusAddress }}
-      metricName: jetty_connections_current_total
-      # Per-replica open-connection ceiling; tuned for Jetty.
-      threshold: "600"
-      query: sum(jetty_connections_current_connections{environment="{{ .Values.environment }}",application="openvsx-server"})
+      metricName: jetty_threads_busy_ratio
+      threshold: "{{ .Values.keda.thresholdBusyRatio | default "0.75" }}"
+      query: |
+        avg(
+          avg_over_time(
+            (
+              jetty_threads_busy{environment="{{ .Values.environment }}",application="openvsx-server"}
+              /
+              jetty_threads_config_max{environment="{{ .Values.environment }}",application="openvsx-server"}
+            )[5m:15s]
+          )
+        )
       authModes: "basic"
     authenticationRef:
       name: {{ .Values.name }}-grafana-cloud-auth

--- a/charts/openvsx/templates/service-monitor.yaml
+++ b/charts/openvsx/templates/service-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.eks.enabled }}
+{{- if not (and .Values.eks.enabled (eq .Values.environment "production")) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -245,7 +245,7 @@ clamav:
     storageClass: "gp3"
   image:
     repository: "ghcr.io/eclipsefdn/clamav-rest-new"
-    tag: "v0.1.1"
+    tag: "v0.1.2"
     pullPolicy: Always
   resources:
     requests:
@@ -271,7 +271,7 @@ yara:
   replicas: 1
   image:
     repository: "ghcr.io/eclipsefdn/yara-rest"
-    tag: "v0.1.0"
+    tag: "v0.1.1"
     pullPolicy: Always
   resources:
     requests:

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -58,7 +58,6 @@ serviceAccount:
 # ── Ingress (ALB/EKS Auto Mode) — fill from TF outputs: vpc→alb_security_group_id, acm→certificate_arn ──
 ingress:
   annotations:
-    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/security-groups: "sg-04eb53c6c5eed3b52"

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -129,7 +129,7 @@ clamav:
   replicas: 1
   image:
     repository: "ghcr.io/eclipsefdn/clamav-rest-new"
-    tag: "v0.1.1"
+    tag: "v0.1.2"
     pullPolicy: Always
   resources:
     requests:
@@ -156,7 +156,7 @@ yara:
   replicas: 1
   image:
     repository: "ghcr.io/eclipsefdn/yara-rest"
-    tag: "v0.1.0"
+    tag: "v0.1.1"
     pullPolicy: Always
   resources:
     requests:

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -111,6 +111,16 @@ keda:
   prometheusAddress: https://prometheus-prod-32-prod-ca-east-0.grafana.net/api/prom
   minReplicas: 6
   maxReplicas: 20
+  pollingInterval: 30
+  cooldownPeriod: 600
+  scaleUp:
+    stabilizationWindowSeconds: 180
+    pods: 2
+    periodSeconds: 120
+  scaleDown:
+    stabilizationWindowSeconds: 900
+    pods: 1
+    periodSeconds: 180
 
 # ── External Secrets Operator — ESO + ClusterSecretStore via eks/helm.tf; secrets from TF secrets/ module ──
 externalSecrets:
@@ -127,6 +137,8 @@ clamav:
   enabled: true
   name: "clamav"
   replicas: 1
+  persistence:
+    storageClass: "gp3-retain"
   image:
     repository: "ghcr.io/eclipsefdn/clamav-rest-new"
     tag: "v0.1.2"

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -26,7 +26,8 @@ esReplicaCount: 3
 image:
   repository: ghcr.io/eclipsefdn/openvsx-website
   pullPolicy: Always
-  tag: ""
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: 97e1417-99
 
 website:
   # MaxDirectMemorySize caps off-heap so the JVM cannot expand past the cgroup limit

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -136,7 +136,7 @@ alloy:
 clamav:
   enabled: true
   name: "clamav"
-  replicas: 1
+  replicas: 3
   persistence:
     storageClass: "gp3-retain"
   image:

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -58,6 +58,9 @@ serviceAccount:
 
 # ── Ingress (ALB/EKS Auto Mode) — fill from TF outputs: vpc→alb_security_group_id, acm→certificate_arn ──
 ingress:
+  preActions:
+    - forward-cors
+    - ssl-redirect
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
@@ -68,9 +71,13 @@ ingress:
     alb.ingress.kubernetes.io/actions.ssl-redirect: >
       {"Type": "redirect", "RedirectConfig":
        {"Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}
+    alb.ingress.kubernetes.io/actions.forward-cors: >
+      {"type":"fixed-response","fixedResponseConfig":{"contentType":"text/plain","statusCode":"204"}}
+    alb.ingress.kubernetes.io/conditions.forward-cors: >
+      [{"field":"http-request-method","httpRequestMethodConfig":{"values":["OPTIONS"]}}]
     alb.ingress.kubernetes.io/healthcheck-path: /actuator/health/readiness
     alb.ingress.kubernetes.io/healthcheck-port: "8081"
-    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=120,routing.http2.enabled=true,deletion_protection.enabled=true
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=60,routing.http2.enabled=true,deletion_protection.enabled=true,client_keep_alive.seconds=60
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30,slow_start.duration_seconds=0
 
 service:

--- a/charts/openvsx/values.yaml
+++ b/charts/openvsx/values.yaml
@@ -139,7 +139,7 @@ clamav:
   replicas: 1
   image:
     repository: "ghcr.io/eclipsefdn/clamav-rest-new"
-    tag: "v0.1.1"
+    tag: "v0.1.2"
     pullPolicy: Always
   resources:
     requests:
@@ -165,7 +165,7 @@ yara:
   replicas: 1
   image:
     repository: "ghcr.io/eclipsefdn/yara-rest"
-    tag: "v0.1.0"
+    tag: "v0.1.1"
     pullPolicy: Always
   resources:
     requests:

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -27,7 +27,7 @@ server:
   jetty:
     threads:
       max: 450
-      max-queue-capacity: 100
+      max-queue-capacity: 50
     connection-idle-timeout: 65000
 spring:
   application:


### PR DESCRIPTION
## Summary

Companion to PR #10471 (aws-main). Three fixes for `aws-production` mirroring the aws-main scope **except** application.yml — which is reverted to match `upstream/production` since aws-production tracks production for app config.

### 1. Align `configuration/application.yml` with `upstream/production`

### 2. Bump scanner images

### 3. Ingress template — default `preActionName`
