### PR TITLE
feat(monitoring): wire eks-staging Alloy to KEDA/ECK/self + gate platform SMs

### DIFF
--- a/charts/openvsx/templates/grafana-alloy.yaml
+++ b/charts/openvsx/templates/grafana-alloy.yaml
@@ -57,6 +57,71 @@ data:
     }
 
     {{- end }}
+
+    // ── KEDA operator (scaler errors, scaling events) ───────────────────────
+    discovery.kubernetes "keda_operator_endpoints" {
+      role = "endpoints"
+      namespaces {
+        names = ["keda"]
+      }
+      selectors {
+        role  = "endpoints"
+        label = "app=keda-operator"
+      }
+    }
+
+    discovery.relabel "keda_operator" {
+      targets = discovery.kubernetes.keda_operator_endpoints.targets
+      rule {
+        source_labels = ["__meta_kubernetes_endpoint_port_name"]
+        regex         = "metricsservice|metrics|http-metrics"
+        action        = "keep"
+      }
+    }
+
+    prometheus.scrape "keda_operator" {
+      targets         = discovery.relabel.keda_operator.output
+      forward_to      = [prometheus.remote_write.default.receiver]
+      scrape_interval = "60s"
+    }
+
+    // ── ECK (Elastic Cloud on Kubernetes) operator ──────────────────────────
+    discovery.kubernetes "eck_operator_endpoints" {
+      role = "endpoints"
+      namespaces {
+        names = ["elastic-system"]
+      }
+      selectors {
+        role  = "endpoints"
+        label = "control-plane=elastic-operator"
+      }
+    }
+
+    discovery.relabel "eck_operator" {
+      targets = discovery.kubernetes.eck_operator_endpoints.targets
+      rule {
+        source_labels = ["__meta_kubernetes_endpoint_port_name"]
+        regex         = "metrics|http-metrics"
+        action        = "keep"
+      }
+    }
+
+    prometheus.scrape "eck_operator" {
+      targets         = discovery.relabel.eck_operator.output
+      forward_to      = [prometheus.remote_write.default.receiver]
+      scrape_interval = "60s"
+    }
+
+    // ── Alloy self-metrics (scrape errors, queue depth, remote_write health) ──
+    prometheus.scrape "alloy_self" {
+      targets = [{
+        __address__ = "127.0.0.1:12345",
+        job         = "alloy",
+      }]
+      forward_to      = [prometheus.remote_write.default.receiver]
+      scrape_interval = "60s"
+    }
+
     prometheus.remote_write "default" {
       external_labels = {
         cluster = sys.env("CLUSTER_NAME"),

--- a/charts/openvsx/templates/kube-state-metrics-monitor.yaml
+++ b/charts/openvsx/templates/kube-state-metrics-monitor.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.eks.enabled }}
+{{- if and .Values.eks.enabled .Values.serviceMonitors.platformMetrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kube-state-metrics-monitor
-  namespace: open-vsx-org-staging
+  namespace: {{ .Values.namespace }}
   labels:
-    app: open-vsx-org
-    environment: staging
+    app: {{ .Values.name }}
+    environment: {{ .Values.environment }}
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/openvsx/templates/node-exporter-service-monitor.yaml
+++ b/charts/openvsx/templates/node-exporter-service-monitor.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.eks.enabled }}
+{{- if and .Values.eks.enabled .Values.serviceMonitors.platformMetrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: node-exporter-monitor
-  namespace: open-vsx-org-staging
+  namespace: {{ .Values.namespace }}
   labels:
-    app: open-vsx-org
-    environment: staging
+    app: {{ .Values.name }}
+    environment: {{ .Values.environment }}
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -40,6 +40,14 @@ image:
 eks:
   enabled: true  # Switch to false for OKD installations
 
+# kube-state-metrics + node-exporter are deployed by EKS Observability (enabled
+# in the AWS console for eks-staging). The two platform ServiceMonitors below
+# point the in-chart Alloy at those services. eks-production has EKS Observability
+# disabled, so values-aws.yaml sets this to false (when/if that file is introduced).
+serviceMonitors:
+  platformMetrics:
+    enabled: true
+
 aws-load-balancer-controller:
   enabled: true
   resources:


### PR DESCRIPTION
## Summary

Closes observability gaps on **eks-staging** by extending the in-chart Grafana Alloy ConfigMap and parameterizing the existing platform ServiceMonitors so they're driven by an explicit feature flag.

- **In-chart Alloy** (`templates/grafana-alloy.yaml`) now scrapes:
  - **KEDA operator** (`keda` ns) — scaler errors and scaling events
  - **ECK operator** (`elastic-system` ns) — Elasticsearch reconcile errors
  - **Alloy self-metrics** (`127.0.0.1:12345`) — scrape errors, queue depth, remote_write health
- **Platform ServiceMonitor templates** (`kube-state-metrics-monitor.yaml`, `node-exporter-service-monitor.yaml`):
  - Gate behind new `.Values.serviceMonitors.platformMetrics.enabled` flag (default unset → off).
  - Replace hardcoded `namespace: open-vsx-org-staging` and `environment: staging` label with `.Values.namespace` / `.Values.environment` so they're correct on any EKS cluster.
- **`values-aws-staging.yaml`**: enable `serviceMonitors.platformMetrics` — kube-state-metrics + prometheus-node-exporter are present on eks-staging via the EKS Observability console toggle.

eks-production is unaffected by this PR — that cluster has EKS Observability disabled, so the flag stays default-off there. Prod-side metric coverage (KSM helm release, native Alloy scrapes for website / KEDA / ESO / ECK / self) is being landed separately in the monitoring Terraform module.

## Test plan

- [x] `helm dependency build charts/openvsx`
- [x] `helm template staging charts/openvsx -f charts/openvsx/values-aws-staging.yaml -n open-vsx-org-staging` — clean render; KSM/node-exporter SMs emit with parameterized labels; Alloy ConfigMap contains the three new scrape blocks
- [x] `helm lint charts/openvsx -f charts/openvsx/values-aws-staging.yaml` — pass
- [x] Render with OKD `values.yaml` (`eks.enabled: false`) — confirms platform SMs are correctly absent
- [ ] After merge + deploy to eks-staging: restart `grafana-alloy-staging` DaemonSet, then verify in Grafana Cloud: `up{job=~"keda_operator|eck_operator|alloy"} == 1`
