### PR TITLE
fix(monitoring): gate platform SMs off for aws-production

### DIFF
--- a/charts/openvsx/templates/kube-state-metrics-monitor.yaml
+++ b/charts/openvsx/templates/kube-state-metrics-monitor.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.eks.enabled }}
+{{- if and .Values.eks.enabled .Values.serviceMonitors.platformMetrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kube-state-metrics-monitor
-  namespace: open-vsx-org-staging
+  namespace: {{ .Values.namespace }}
   labels:
-    app: open-vsx-org
-    environment: staging
+    app: {{ .Values.name }}
+    environment: {{ .Values.environment }}
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/openvsx/templates/node-exporter-service-monitor.yaml
+++ b/charts/openvsx/templates/node-exporter-service-monitor.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.eks.enabled }}
+{{- if and .Values.eks.enabled .Values.serviceMonitors.platformMetrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: node-exporter-monitor
-  namespace: open-vsx-org-staging
+  namespace: {{ .Values.namespace }}
   labels:
-    app: open-vsx-org
-    environment: staging
+    app: {{ .Values.name }}
+    environment: {{ .Values.environment }}
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -12,6 +12,14 @@ host: open-vsx.org
 eks:
   enabled: true
 
+# eks-production has EKS Observability disabled — no kube-state-metrics or
+# prometheus-node-exporter installed on the cluster. KSM is deployed by the
+# monitoring Terraform module (tf-resources/aws/eu-central-1/monitoring) and
+# scraped by Alloy natively; the chart-emitted platform ServiceMonitors stay off.
+serviceMonitors:
+  platformMetrics:
+    enabled: false
+
 # ── Subcharts NOT used in aws-production ────────────────────────────────────────
 # postgresql-ha: prod uses AWS RDS (tf-resources/aws/eu-central-1/rds), not in-cluster Postgres
 # aws-load-balancer-controller: EKS Auto Mode ships an integrated ALB controller — no standalone install


### PR DESCRIPTION
## Summary

Unblocks the first helm install on **eks-production** by gating the two platform ServiceMonitors so they're not emitted on a cluster that has neither the `monitoring.coreos.com` CRD nor the kube-state-metrics / prometheus-node-exporter services.

The current templates (`kube-state-metrics-monitor.yaml`, `node-exporter-service-monitor.yaml`) emit unconditionally when `eks.enabled: true` and hardcode `namespace: open-vsx-org-staging` + `environment: staging`. On eks-production this fails server-side validation:

```
Error: ... resource mapping not found for name: "kube-state-metrics-monitor" namespace: "open-vsx-org-staging":
  no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first
```

## Changes

- `templates/kube-state-metrics-monitor.yaml` / `templates/node-exporter-service-monitor.yaml`: gate behind new `serviceMonitors.platformMetrics.enabled` flag (matching the gate added on `aws-main` in #10507); parameterize namespace and environment label so the templates render correctly on any EKS cluster when opted in.
- `values-aws.yaml`: explicitly set `serviceMonitors.platformMetrics.enabled: false`. eks-production has EKS Observability disabled (no KSM / node-exporter on the cluster); KSM is deployed by the monitoring Terraform module and scraped by Alloy natively, and node-exporter coverage comes from Alloy's existing kubelet + cAdvisor scrapes.

No template or values changes for KEDA / ESO / ECK / Alloy-self scraping — all of those live in the monitoring TF module (`alloy-config.alloy.tpl`).

## Test plan

- [x] `helm template aws-production charts/openvsx -f charts/openvsx/values-aws.yaml -n open-vsx-org --set image.tag=d0a3720-194` — clean render; **0** `ServiceMonitor` resources emitted; all expected app resources still present (Deployment, StatefulSet, Service, Ingress, ExternalSecret, ScaledObject, etc.).

## Related

- Staging-side PR with the same gate (default-on for staging): #10507