### PR TITLE
fix(clamav): gate PVC behind !eks.enabled

### DIFF
--- a/charts/openvsx/templates/clamav-rest/pvc.yaml
+++ b/charts/openvsx/templates/clamav-rest/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clamav.enabled }}
+{{- if and .Values.clamav.enabled (not .Values.eks.enabled) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
## Summary
- Gate `clamav-rest/pvc.yaml` so the PersistentVolumeClaim is only rendered when `eks.enabled` is **false**.
- The PVC uses `ReadWriteMany`, which the OKD storage class supports but the default EBS-backed StorageClass on EKS does not. On EKS the clamav-rest workload uses a different storage path, so this PVC should not render.

## Diff
```diff
-{{- if .Values.clamav.enabled }}
+{{- if and .Values.clamav.enabled (not .Values.eks.enabled) }}
```