### PR TITLE
Deploy v0.34.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG SERVER_VERSION=v0.34.5
-ARG SERVER_VERSION_STRING=v0.34.5
+ARG SERVER_VERSION=v0.34.6
+ARG SERVER_VERSION_STRING=v0.34.6
 
 # Builder image to compile the website
 FROM ubuntu:24.04 AS builder

--- a/charts/openvsx/templates/yara-rest/pvc.yaml
+++ b/charts/openvsx/templates/yara-rest/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: yara-rules
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 2Gi

--- a/charts/openvsx/values.yaml
+++ b/charts/openvsx/values.yaml
@@ -118,7 +118,7 @@ clamav:
   replicas: 1
   image:
     repository: "ghcr.io/eclipsefdn/clamav-rest-new"
-    tag: "v0.1.1"
+    tag: "v0.1.2"
     pullPolicy: Always
   resources:
     requests:
@@ -144,7 +144,7 @@ yara:
   replicas: 1
   image:
     repository: "ghcr.io/eclipsefdn/yara-rest"
-    tag: "v0.1.0"
+    tag: "v0.1.1"
     pullPolicy: Always
   resources:
     requests:

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -297,6 +297,7 @@ ovsx:
             file-field: "file"
           response:
             format: json
+            error-path: "$.error"
             # Our wrapper returns: { status, threats[], scanned_files, scan_time_ms }
             threats-path: "$.threats[*]"
             threat-mapping:
@@ -338,6 +339,7 @@ ovsx:
             file-field: "file"
           response:
             format: json
+            error-path: "$.error"
             # Matches are returned as an array
             threats-path: "$.matches[*]"
             threat-mapping:

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "dependencies": {
-    "openvsx-webui": "^0.20.3"
+    "openvsx-webui": "^0.20.4"
   },
   "resolutions": {
     "qs": "^6.14.1"

--- a/website/src/page-settings.tsx
+++ b/website/src/page-settings.tsx
@@ -228,11 +228,9 @@ export default function createPageSettings(
   //---------- CLAIM NAMESPACE LINK
   const claimNamespace: FunctionComponent<{ extension: Extension; sx: SxProps<Theme> }> = ({ sx, extension }) => {
     const title = `Claiming namespace \`${extension.namespace}\``;
-    const body =
-      'Briefly explain what makes you a legitimate owner of the namespace mentioned in the issue title.\nPlease ensure that you have logged in to https://open-vsx.org at least once, otherwise we cannot process your request.';
     return (
       <Link
-        href={`https://github.com/EclipseFdn/open-vsx.org/issues/new?labels=namespace&title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`}
+        href={`https://github.com/EclipseFdn/open-vsx.org/issues/new?template=claim-namespace-ownership.yml&namespace=${encodeURIComponent(extension.namespace)}&title=${encodeURIComponent(title)}`}
         target='_blank'
         variant='body2'
         color='secondary'

--- a/website/src/page-settings.tsx
+++ b/website/src/page-settings.tsx
@@ -166,12 +166,8 @@ export default function createPageSettings(
         <InfoIcon fontSize='large' />
       </Box>
       <Typography variant='body1'>
-        Open VSX is growing! To support reliable access as usage increases, we&apos;ve implemented rate limiting tiers
-        that govern usage. Learn more{' '}
-        <Link color='secondary' underline='hover' href='https://github.com/EclipseFdn/open-vsx.org/wiki/rate-limiting'>
-          here
-        </Link>
-        .
+        Open VSX will be in read only mode from 10:00AM EST - 12:00AM EST on Friday May 29th. Publishing and related
+        activities will be disabled during this time.
       </Typography>
     </Box>
   );
@@ -262,7 +258,7 @@ export default function createPageSettings(
           color: 'info'
         },
         cookie: {
-          key: 'Rate-Limit-Announcement',
+          key: 'AWS-Migration',
           value: 'closed',
           path: '/'
         }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4415,7 +4415,7 @@ __metadata:
     eslint: "npm:^9.39.0"
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-react: "npm:^7.37.0"
-    openvsx-webui: "npm:^0.20.3"
+    openvsx-webui: "npm:^0.20.4"
     prettier: "npm:^3.8.1"
     rollup-plugin-visualizer: "npm:^7.0.1"
     typescript: "npm:^5.9.0"
@@ -4439,9 +4439,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openvsx-webui@npm:^0.20.3":
-  version: 0.20.3
-  resolution: "openvsx-webui@npm:0.20.3"
+"openvsx-webui@npm:^0.20.4":
+  version: 0.20.4
+  resolution: "openvsx-webui@npm:0.20.4"
   dependencies:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
@@ -4471,7 +4471,7 @@ __metadata:
     react-infinite-scroller: "npm:^1.2.6"
     react-router: "npm:^6.30.3"
     react-router-dom: "npm:^6.30.3"
-  checksum: 10/76877a3dd692c117835b60f9782f0df8d7b0501596a482fc35367d8dd39b46fac50223779e774f21590e892f0dffae3e416b7f5f964836b5f5728a4eb3f4649e
+  checksum: 10/d98c3a96a6d19456da9f5295f16cf3f2cf6257ac15da2f9d5b616ed9b6e3f9e4293527b0f76983576b381f194a0bbc8e71243c916ace8a93d309ac2bbf0c9e9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This deploys [v0.34.6](https://github.com/eclipse-openvsx/openvsx/releases/tag/v0.34.6) to production with the following changes:

 - update to latest version of clamav and yara service already running on staging
 - fix namespace claim issue template
 - fix yara pvc mode after it was changed manually already

Notable changes in 0.34.6:

 - consistent cache control headers for all public endpoints and 404 errors to be able to cache them properly
 - support for retrying failed scans in the admin dashboard
 - fix for the vscode latest endpoint wrt version sorting
 - support for an extensionquery endpoint with GET to support caching

Fixes #10622
