### PR TITLE
aws-production: cut over to prod S3 buckets + wire SMTP credentials

### DIFF
--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -58,6 +58,8 @@ spec:
             mail:
               host: "mail.eclipse.org"
               port: 25
+              username: "{{ "{{" }} .mail_username {{ "}}" }}"
+              password: "{{ "{{" }} .mail_password {{ "}}" }}"
               properties:
                 mail:
                   smtp:
@@ -145,6 +147,14 @@ spec:
       remoteRef:
         key: openvsx/production/oauth
         property: github_client_secret
+    - secretKey: mail_username
+      remoteRef:
+        key: openvsx/production/mail
+        property: username
+    - secretKey: mail_password
+      remoteRef:
+        key: openvsx/production/mail
+        property: password
 ---
 # ── grafana-cloud-secret-production ──────────────────────────────────────────
 # SM keys match K8s keys exactly — dataFrom.extract maps them 1:1.

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -144,11 +144,8 @@ externalSecrets:
   enabled: true
   clusterSecretStore: aws-secrets-manager
   refreshInterval: 1h
-  # TODO(cutover): revert to "fastlyopenvsxorg" after EKS cutover validation completes.
-  fastlyLogsBucket: "openvsxorgstagingdx"
-  # TODO(cutover): revert to "openvsxorg" after EKS cutover validation completes.
-  storageBucket: "openvsxorgstaging"
-  # TODO(cutover): revert to false after EKS cutover validation — otherwise ES rebuilds on every pod restart.
+  fastlyLogsBucket: "fastlyopenvsxorg"
+  storageBucket: "openvsxorg"
   elasticsearchClearOnStart: true
 
 # ── Grafana Alloy — disabled; monitoring/ TF module manages Alloy cluster-wide with IRSA (OKD nodeSelector won't match EKS) ──


### PR DESCRIPTION
## What

Cutover prep for the EKS production deploy:

1. **Prod S3 buckets** — revert the cutover-validation overrides in `values-aws.yaml` so the app reads prod buckets:
   - `fastlyLogsBucket`: `openvsxorgstagingdx` → `fastlyopenvsxorg`
   - `storageBucket`: `openvsxorgstaging` → `openvsxorg`
2. **SMTP credentials** — add `spring.mail.username`/`password` to the `deployment-configuration-production` ExternalSecret, sourced from a new `openvsx/production/mail` Secrets Manager secret.

## Verification

- `helm template` renders the new `mail_username`/`mail_password` placeholders and prod bucket names.