### PR TITLE
Enhance security context in clamav-rest statefulset

### DIFF
--- a/charts/openvsx/templates/clamav-rest/statefulset.yaml
+++ b/charts/openvsx/templates/clamav-rest/statefulset.yaml
@@ -24,10 +24,22 @@ spec:
         component: {{ .Values.clamav.name }}-{{ .Values.environment }}
     spec:
       terminationGracePeriodSeconds: 10
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: "Always"
       containers:
         - name: {{ .Values.clamav.name }}-{{ .Values.environment }}
           image: "{{ .Values.clamav.image.repository }}:{{ .Values.clamav.image.tag }}"
           imagePullPolicy: {{ .Values.clamav.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            capabilities:
+              drop:
+                - ALL
           ports:
             - name: http
               containerPort: {{ .Values.clamav.service.port }}


### PR DESCRIPTION
Add security context to statefulset for ClamAV.

This applies the same settings as for yara also for clamav.

We probably need to test that first on staging.