### PR TITLE
Increase limits for file upload and processing for clamav

### DIFF
--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -176,9 +176,9 @@ clamav:
     MAX_UPLOAD_SIZE_MB: 512
     MAX_EXTRACTED_SIZE_MB: 512
     MAX_FILE_COUNT: 100000
-    MAX_SINGLE_FILE_MB: 300
+    MAX_SINGLE_FILE_MB: 512
     MAX_RECURSION: 16
-    MAX_THREADS: 4
+    MAX_THREADS: 10
     SCAN_TIMEOUT_MINUTES: 5
 
 # ── YARA ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Align values for aws-production from previous deployment to avoid occasional errors from clamav.