### PR TITLE
fix(logging): drop traceID stream label, revert staging debug levels

### DIFF
--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -10,8 +10,6 @@ logging:
     org.springframework.boot.autoconfigure.web.servlet.WelcomePageHandlerMapping: "error"
     # reduce log verbosity for redis connection watchdog
     io.lettuce.core.protocol: "warn"
-    org.eclipse.openvsx.ratelimit: "debug"
-    org.eclipse.openvsx.scanning: "debug"
 
 server:
   address: 0.0.0.0

--- a/configuration/logback-spring.xml
+++ b/configuration/logback-spring.xml
@@ -12,7 +12,9 @@
         </http>
         <format>
             <label>
-                <pattern>job=loki4j,environment=${ENVNAME},instance=${HOSTNAME},application=${appName},traceID=%X{traceId:-NONE},level=%level</pattern>
+                <!-- traceID must NOT be a label: unbounded cardinality created one Loki
+                     stream per request and exhausted the tenant's 5k active-stream limit -->
+                <pattern>job=loki4j,environment=${ENVNAME},instance=${HOSTNAME},application=${appName},level=%level</pattern>
             </label>
             <message>
                 <pattern>${FILE_LOG_PATTERN}</pattern>


### PR DESCRIPTION
## Problem

On 2026-06-03 (~13:00–21:00 UTC) the Grafana Cloud Loki tenant hit its 5,000 active-stream limit. Alloy collectors received `429 maximum active stream limit exceeded` and **dropped log batches for all workloads** (app, clamav/yara scan logs, elasticsearch). Active streams surged from a steady ~270 to a recorded peak of 4,955 (20-min metric scrape — true peak crossed the limit; discards peaked at ~10,200 samples/sec).

## Root cause

`configuration/logback-spring.xml` uses `traceID=%X{traceId}` as a **Loki stream label**. Trace IDs are unique per request → one stream per request. Staging runs `org.eclipse.openvsx.{ratelimit,scanning}` at DEBUG (added for scan-pipeline validation), so nearly every request emitted log lines, each creating a new stream. Staging and production share the Loki tenant, so staging's burst dropped production logs too.

## Changes

- Remove `traceID` from the Loki4j label pattern. The trace id is already in every log line via Spring Boot's correlation pattern (`[traceId-spanId]`) — correlation still works with a line filter (`|= "<traceid>"`).
- Revert the two staging DEBUG package levels to inherit root `info`.
