### PR TITLE
fix(keda): correct EKS production autoscaling — Value semantics, reachable threshold, CPU safety net

### DIFF
--- a/charts/openvsx/templates/scaledobject.yaml
+++ b/charts/openvsx/templates/scaledobject.yaml
@@ -27,11 +27,12 @@ spec:
               value: {{ .Values.keda.scaleDown.pods | default 1 }}
               periodSeconds: {{ .Values.keda.scaleDown.periodSeconds | default 180 }}
   triggers:
-  # Single signal: avg pod busy/max ratio, smoothed over 5m. Self-normalizing
-  # across jetty.threads.max changes — threshold stays valid at any cap.
-  # Filter on the environment label (set by management.metrics.tags) so this
-  # survives Alloy scrape-config changes that may or may not inject namespace.
+  # Avg pod busy/max ratio — self-normalizing across jetty.threads.max changes.
+  # metricType Value: the ratio query never exceeds 1.0, so AverageValue semantics
+  # (desired = ceil(value/threshold)) cap demand at ceil(1/threshold) pods at any load.
+  # Value semantics scale proportionally: desired = current * value/threshold.
   - type: prometheus
+    metricType: Value
     metadata:
       serverAddress: {{ .Values.keda.prometheusAddress }}
       metricName: jetty_threads_busy_ratio
@@ -40,13 +41,21 @@ spec:
         avg(
           avg_over_time(
             (
-              jetty_threads_busy{environment="{{ .Values.environment }}",application="openvsx-server"}
+              jetty_threads_busy{environment="{{ .Values.environment }}",application="openvsx-server"{{- if .Values.keda.clusterName }},cluster="{{ .Values.keda.clusterName }}"{{- end }}}
               /
-              jetty_threads_config_max{environment="{{ .Values.environment }}",application="openvsx-server"}
-            )[5m:15s]
+              jetty_threads_config_max{environment="{{ .Values.environment }}",application="openvsx-server"{{- if .Values.keda.clusterName }},cluster="{{ .Values.keda.clusterName }}"{{- end }}}
+            )[{{ .Values.keda.smoothingWindow | default "5m" }}:30s]
           )
         )
       authModes: "basic"
     authenticationRef:
       name: {{ .Values.name }}-grafana-cloud-auth
+{{- if .Values.keda.cpuUtilization }}
+  # In-cluster safety net via metrics-server — keeps scale-up functional when the
+  # Grafana Cloud round-trip (app -> Alloy -> Grafana Cloud -> KEDA) is down.
+  - type: cpu
+    metricType: Utilization
+    metadata:
+      value: "{{ .Values.keda.cpuUtilization }}"
+{{- end }}
 {{- end }}

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -10,6 +10,7 @@ replicaCount: 6
 esReplicaCount: 3
 keda:
   enabled: true
+  clusterName: eks-staging
   minReplicas: 12
   maxReplicas: 18
   prometheusAddress: "https://prometheus-prod-32-prod-ca-east-0.grafana.net/api/prom"

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -120,13 +120,10 @@ es:
   storage: 1Gi
 
 # ── KEDA — Jetty busy-thread ratio (Grafana Cloud) + CPU safety net (metrics-server) ──
-# Was Tomcat-based; the app runs Jetty (Spring Boot embedded), so the old queries
-# returned empty and autoscaling never fired. maxReplicas raised after the 2026-05-19
-# incident saturated 12 OKD replicas.
-# Threshold 0.15 from post-cutover baseline (2026-05-29..06-04): steady avg ratio
-# 0.011-0.03, worst hour 0.08 — old 0.75 was unreachable. minReplicas 8 makes the
-# 2026-05-29 manual bump permanent. clusterName pins the query to EKS series only
-# (pre-cutover the unpinned selector matched OKD prod pods too).
+# Threshold is derived from the observed production baseline: well above steady-state
+# noise, low enough to fire before thread saturation. clusterName pins the query to
+# this cluster's series so co-labeled metrics from other clusters can't skew the
+# average. The CPU trigger scales via metrics-server, independent of Grafana Cloud.
 keda:
   enabled: true
   prometheusAddress: https://prometheus-prod-32-prod-ca-east-0.grafana.net/api/prom

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -132,7 +132,9 @@ keda:
   prometheusAddress: https://prometheus-prod-32-prod-ca-east-0.grafana.net/api/prom
   clusterName: eks-production-openvsx
   minReplicas: 8
-  maxReplicas: 20
+  # 15 caps fleet Hikari pools at 450 of RDS max_connections=500 (30/pod, pinned
+  # open). Raise only after shrinking the pool size.
+  maxReplicas: 15
   pollingInterval: 30
   cooldownPeriod: 600
   thresholdBusyRatio: "0.15"

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -119,21 +119,29 @@ es:
   storage_class: gp3-retain
   storage: 1Gi
 
-# ── KEDA — Jetty threads/connections via Prometheus (monitoring ns, eks/helm.tf) ──
+# ── KEDA — Jetty busy-thread ratio (Grafana Cloud) + CPU safety net (metrics-server) ──
 # Was Tomcat-based; the app runs Jetty (Spring Boot embedded), so the old queries
 # returned empty and autoscaling never fired. maxReplicas raised after the 2026-05-19
 # incident saturated 12 OKD replicas.
+# Threshold 0.15 from post-cutover baseline (2026-05-29..06-04): steady avg ratio
+# 0.011-0.03, worst hour 0.08 — old 0.75 was unreachable. minReplicas 8 makes the
+# 2026-05-29 manual bump permanent. clusterName pins the query to EKS series only
+# (pre-cutover the unpinned selector matched OKD prod pods too).
 keda:
   enabled: true
   prometheusAddress: https://prometheus-prod-32-prod-ca-east-0.grafana.net/api/prom
-  minReplicas: 6
+  clusterName: eks-production-openvsx
+  minReplicas: 8
   maxReplicas: 20
   pollingInterval: 30
   cooldownPeriod: 600
+  thresholdBusyRatio: "0.15"
+  smoothingWindow: 3m
+  cpuUtilization: 70
   scaleUp:
-    stabilizationWindowSeconds: 180
-    pods: 2
-    periodSeconds: 120
+    stabilizationWindowSeconds: 60
+    pods: 4
+    periodSeconds: 60
   scaleDown:
     stabilizationWindowSeconds: 900
     pods: 1

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -27,7 +27,7 @@ server:
   jetty:
     threads:
       max: 450
-      max-queue-capacity: 50
+      max-queue-capacity: 500
     # Must exceed the ALB idle_timeout (values-aws.yaml: 300s) so the ALB never
     # tries to reuse a Jetty-closed connection — otherwise the client sees 502s.
     connection-idle-timeout: 310000


### PR DESCRIPTION
Production autoscaling on EKS has never fired. Three issues in the ScaledObject:

- The 0.75 busy-thread threshold is unreachable. Measured steady state since the cutover is 0.011–0.03, worst hour 0.08.
- The trigger used the default `AverageValue` metricType. Our query is a ratio that never exceeds 1.0, so the HPA could never ask for more than `ceil(1/0.75)` = 2 pods, even fully saturated.
- The query wasn't pinned to a cluster, so before cutover it averaged OKD and EKS pods together.

This also makes the manual minReplicas bump to 8 (done during cutover) permanent, so the next deploy doesn't silently drop it back to 6.

Changes:

- `metricType: Value` — desired replicas now scale proportionally with the signal
- threshold 0.15 (5× steady baseline, 2× worst observed hour), smoothing 5m → 3m, scale-up 4 pods/min
- query pinned to `eks-production-openvsx` via a new `keda.clusterName` value
- in-cluster CPU trigger (70%) through metrics-server, so scaling keeps working if Grafana Cloud is unreachable
- maxReplicas capped at 15: each pod pins a 30-connection Hikari pool and RDS max_connections is 500, so 20 pods (600 connections) would exhaust it mid-burst; 15×30 = 450 leaves operational headroom. Can go back up once the pool size is reduced (fleet-wide peak active connections this week was 29).
- Also raises Jetty max-queue-capacity 50 → 500: the 50-task handoff queue rejected burst submissions even with idle threads (the recurring RejectedExecutionException alert). 500 ≈ 3× the worst observed per-pod burst and ≥ threads.max.

Validation: server-side dry-run against prod, the exact rendered query checked against Grafana Cloud, and a replay of the proposed signal over the whole post-cutover week — zero scale events, no flapping, min-8 floor holds. We also rehearsed the full loop on eks-staging: under synthetic load the app scaled 2→6 in about 3 minutes with the expected math, and drained back 1 pod per 3 minutes after the 15-minute calm window. Staging was restored to its original state afterwards.

One known non-goal: the May 29 thread saturation was cold JVMs during a rollout, not a capacity problem — warmup/readiness gating is a separate follow-up.

Companion PR for aws-main: #10893

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>
