### PR TITLE
fix(keda): ScaledObject correctness — Value semantics, cluster-pinned query, optional CPU trigger

### DIFF
--- a/charts/openvsx/templates/scaledobject.yaml
+++ b/charts/openvsx/templates/scaledobject.yaml
@@ -27,11 +27,12 @@ spec:
               value: {{ .Values.keda.scaleDown.pods | default 1 }}
               periodSeconds: {{ .Values.keda.scaleDown.periodSeconds | default 180 }}
   triggers:
-  # Single signal: avg pod busy/max ratio, smoothed over 5m. Self-normalizing
-  # across jetty.threads.max changes — threshold stays valid at any cap.
-  # Filter on the environment label (set by management.metrics.tags) so this
-  # survives Alloy scrape-config changes that may or may not inject namespace.
+  # Avg pod busy/max ratio — self-normalizing across jetty.threads.max changes.
+  # metricType Value: the ratio query never exceeds 1.0, so AverageValue semantics
+  # (desired = ceil(value/threshold)) cap demand at ceil(1/threshold) pods at any load.
+  # Value semantics scale proportionally: desired = current * value/threshold.
   - type: prometheus
+    metricType: Value
     metadata:
       serverAddress: {{ .Values.keda.prometheusAddress }}
       metricName: jetty_threads_busy_ratio
@@ -40,13 +41,21 @@ spec:
         avg(
           avg_over_time(
             (
-              jetty_threads_busy{environment="{{ .Values.environment }}",application="openvsx-server"}
+              jetty_threads_busy{environment="{{ .Values.environment }}",application="openvsx-server"{{- if .Values.keda.clusterName }},cluster="{{ .Values.keda.clusterName }}"{{- end }}}
               /
-              jetty_threads_config_max{environment="{{ .Values.environment }}",application="openvsx-server"}
-            )[5m:15s]
+              jetty_threads_config_max{environment="{{ .Values.environment }}",application="openvsx-server"{{- if .Values.keda.clusterName }},cluster="{{ .Values.keda.clusterName }}"{{- end }}}
+            )[{{ .Values.keda.smoothingWindow | default "5m" }}:30s]
           )
         )
       authModes: "basic"
     authenticationRef:
       name: {{ .Values.name }}-grafana-cloud-auth
+{{- if .Values.keda.cpuUtilization }}
+  # In-cluster safety net via metrics-server — keeps scale-up functional when the
+  # Grafana Cloud round-trip (app -> Alloy -> Grafana Cloud -> KEDA) is down.
+  - type: cpu
+    metricType: Utilization
+    metadata:
+      value: "{{ .Values.keda.cpuUtilization }}"
+{{- end }}
 {{- end }}

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -17,6 +17,7 @@ autoscaling:
 
 keda:
   enabled: true
+  clusterName: eks-staging
   minReplicas: 12
   maxReplicas: 18
   prometheusAddress: "https://prometheus-prod-32-prod-ca-east-0.grafana.net/api/prom"


### PR DESCRIPTION
Two correctness fixes in the KEDA ScaledObject template (full analysis and measurements in #10892):

- `metricType: Value` — the prometheus trigger used the default `AverageValue`, which for a ratio query (never above 1.0) caps replica demand at `ceil(1/threshold)` pods regardless of load.
- The query can now be pinned to a single cluster via `keda.clusterName`; without the pin, co-labeled series from other clusters pollute the average. Staging values set `eks-staging` (verified against the live series).

Also parameterizes the smoothing window and adds an optional in-cluster CPU trigger, rendered only when `keda.cpuUtilization` is set. Staging tuning values are unchanged.

Tested end-to-end on eks-staging — details in #10892.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>
