### PR TITLE
fix(chart): protect ES from Karpenter consolidation + make all env files render

### DIFF
--- a/charts/openvsx/templates/clamav-rest/statefulset.yaml
+++ b/charts/openvsx/templates/clamav-rest/statefulset.yaml
@@ -77,8 +77,10 @@ spec:
       name: clamav-db
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: {{ .Values.clamav.persistence.storageClass | quote }}
+      {{- with (default dict .Values.clamav.persistence).storageClass }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
       resources:
         requests:
-          storage: {{ .Values.clamav.persistence.size | default "5Gi" }}
+          storage: {{ (default dict .Values.clamav.persistence).size | default "5Gi" }}
 {{- end }}

--- a/charts/openvsx/templates/elasticsearch.yaml
+++ b/charts/openvsx/templates/elasticsearch.yaml
@@ -36,6 +36,10 @@ spec:
         labels:
           app: {{ .Values.name }}
           environment: {{ .Values.environment }}
+        {{- with .Values.es.podAnnotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         affinity:
           podAntiAffinity:

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -79,12 +79,9 @@ resources:
 
 # elastic search
 es:
-  commonAnnotations:
+  podAnnotations:
     "karpenter.sh/do-not-disrupt": "true"
     "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
-  pdb:
-    create: true
-    minAvailable: 1
   java_opts: -Xms1g -Xmx1g -Dlog4j2.formatMsgNoLookups=true
   resources:
     limits:

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -35,6 +35,7 @@ eks:
   enabled: true  # Switch to false for OKD installations
 
 aws-load-balancer-controller:
+  enabled: true
   resources:
   requests:
     cpu: 100m

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -109,6 +109,9 @@ resources:
 # ── Elasticsearch ─────────────────────────────────────────────────────────────
 es:
   java_opts: -Xms4g -Xmx4g -Dlog4j2.formatMsgNoLookups=true
+  # Stop Karpenter (Auto Mode) from draining the ES pod's node during consolidation
+  podAnnotations:
+    karpenter.sh/do-not-disrupt: "true"
   resources:
     limits:
       cpu: 4

--- a/charts/openvsx/values.yaml
+++ b/charts/openvsx/values.yaml
@@ -33,6 +33,15 @@ image:
 eks:
   enabled: false
 
+# Platform ServiceMonitors (node-exporter, kube-state-metrics) — EKS-only, off by default.
+serviceMonitors:
+  platformMetrics:
+    enabled: false
+
+# EKS-only subchart — OKD has no ALB. Off by default; enabled explicitly on EKS staging.
+aws-load-balancer-controller:
+  enabled: false
+
 website:
   jvmArgs: >
     -Xms6G -Xmx8G


### PR DESCRIPTION
## What

Two independent fixes, kept as separate commits:

**1. Elasticsearch disruption protection.** Adds `karpenter.sh/do-not-disrupt` to the ES podTemplate (prod + staging) and wires the chart to read `es.podAnnotations`. Today's app rollout let EKS Auto Mode (Karpenter) consolidate the node hosting an ES pod, taking a shard offline for ~2 min and 503-ing search at the origin. Also drops the dead, quorum-unsafe `es.pdb` override in staging — `templates/pdb.yaml` hardcodes the correct `minAvailable: 2`, and the override (`minAvailable: 1`) would have permitted a quorum-breaking double eviction on a 3-node cluster if anyone ever wired it in.

**2. Chart render fixes / env guards.** Base `values.yaml` now defaults `serviceMonitors` and `aws-load-balancer-controller` to off; the ALB controller is EKS-only and was failing OKD renders on a missing `clusterName`. It's enabled explicitly on EKS staging. ClamAV `persistence` reads are made nil-safe. All five env value files now `helm template` cleanly.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>