### PR TITLE
fix(chart): protect ES from Karpenter consolidation + make all env files render

### DIFF
--- a/charts/openvsx/templates/clamav-rest/statefulset.yaml
+++ b/charts/openvsx/templates/clamav-rest/statefulset.yaml
@@ -77,8 +77,10 @@ spec:
       name: clamav-db
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: {{ .Values.clamav.persistence.storageClass | quote }}
+      {{- with (default dict .Values.clamav.persistence).storageClass }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
       resources:
         requests:
-          storage: {{ .Values.clamav.persistence.size | default "5Gi" }}
+          storage: {{ (default dict .Values.clamav.persistence).size | default "5Gi" }}
 {{- end }}

--- a/charts/openvsx/templates/elasticsearch.yaml
+++ b/charts/openvsx/templates/elasticsearch.yaml
@@ -36,6 +36,10 @@ spec:
         labels:
           app: {{ .Values.name }}
           environment: {{ .Values.environment }}
+        {{- with .Values.es.podAnnotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         affinity:
           podAntiAffinity:

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -115,12 +115,9 @@ resources:
 
 # elastic search
 es:
-  commonAnnotations:
+  podAnnotations:
     "karpenter.sh/do-not-disrupt": "true"
     "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
-  pdb:
-    create: true
-    minAvailable: 1
   java_opts: -Xms1g -Xmx1g -Dlog4j2.formatMsgNoLookups=true
   resources:
     limits:

--- a/charts/openvsx/values.yaml
+++ b/charts/openvsx/values.yaml
@@ -41,6 +41,15 @@ image:
 eks:
   enabled: false
 
+# Platform ServiceMonitors (node-exporter, kube-state-metrics) — EKS-only, off by default.
+serviceMonitors:
+  platformMetrics:
+    enabled: false
+
+# EKS-only subchart — OKD has no ALB. Off by default; enabled explicitly on EKS staging.
+aws-load-balancer-controller:
+  enabled: false
+
 website:
   jvmArgs: >
     -Xms4G -Xmx6G


### PR DESCRIPTION
## What

Companion to #10960, applied to `aws-main`. This branch has no `values-aws.yaml` yet, so the ES protection here is staging-only; everything else matches.

**1. Elasticsearch disruption protection.** Adds `karpenter.sh/do-not-disrupt` to the ES podTemplate via `es.podAnnotations` (staging). Drops the dead, quorum-unsafe `es.pdb` override in staging (`templates/pdb.yaml` already hardcodes the correct `minAvailable: 2`). Background: on 2026-06-08 a routine app rollout let Karpenter consolidate the node hosting a prod ES pod and took a shard offline for ~2 min.

**2. Chart render fixes / env guards.** Base `values.yaml` defaults `serviceMonitors` and `aws-load-balancer-controller` to off (the ALB controller is EKS-only and was failing the OKD renders on a missing `clusterName`); nil-safe ClamAV `persistence` reads. All env value files now `helm template` cleanly.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>