### PR TITLE
ci: trigger EKS staging deploy on aws-main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
       when {
         anyOf {
         expression { return env.BRANCH_NAME.startsWith('feature') }
-        branch 'eks-main'
+        branch 'aws-main'
       }
       }
       steps {


### PR DESCRIPTION
## What

Change the *Deploy to EKS staging environment* stage trigger from the
non-existent `eks-main` branch to `aws-main`.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>
