### PR TITLE
ci: trigger EKS staging deploy on aws-main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
       when {
         anyOf {
         expression { return env.BRANCH_NAME.startsWith('feature') }
-        branch 'eks-main'
+        branch 'aws-main'
       }
       }
       steps {


### PR DESCRIPTION
## What

Mirror the staging-stage trigger fix onto `aws-production`: change the
*Deploy to EKS staging environment* stage from the non-existent
`eks-main` branch to `aws-main`.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>
