### PR TITLE
ci: add dedicated aws-staging deploy stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,24 +92,6 @@ pipeline {
       }
     }
 
-    stage('Deploy to EKS staging environment') {
-      when {
-        anyOf {
-        expression { return env.BRANCH_NAME.startsWith('feature') }
-        branch 'aws-main'
-      }
-      }
-      steps {
-        container('eks') {
-          withKubeConfig([credentialsId: 'ci-bot-eks-staging-token', serverUrl: 'https://5CF0970816FA7A7C340E6BEF8575A8D4.gr7.eu-central-1.eks.amazonaws.com']) {
-            sh '''
-              ./kubernetes/helm-deploy.sh aws-staging "${IMAGE_TAG}"
-            '''
-          }
-        }
-      }
-    }
-
     stage('Deploy test') {
       when {
         branch 'test'
@@ -149,6 +131,28 @@ pipeline {
           withKubeConfig([credentialsId: 'ci-bot-okd-c1-token', serverUrl: 'https://api.okd-c1.eclipse.org:6443']) {
             sh '''
               ./kubernetes/helm-deploy.sh production "${IMAGE_TAG}"
+            '''
+          }
+        }
+      }
+    }
+
+    stage('Deploy aws-staging') {
+      when {
+        branch 'aws-main'
+      }
+      steps {
+        container('eks') {
+          withCredentials([
+            string(credentialsId: 'jenkins-openvsx-aws-key-id',     variable: 'AWS_ACCESS_KEY_ID'),
+            string(credentialsId: 'jenkins-openvsx-aws-secret-key', variable: 'AWS_SECRET_ACCESS_KEY'),
+          ]) {
+            sh '''
+              set -e
+              export AWS_DEFAULT_REGION=eu-central-1
+              export KUBECONFIG="${HOME}/.kube/config"
+              aws eks update-kubeconfig --name eks-staging --region eu-central-1
+              ./kubernetes/helm-deploy.sh aws-staging "${IMAGE_TAG}"
             '''
           }
         }


### PR DESCRIPTION
The aws-main branch deploys to the EKS staging cluster, but that deploy was riding on the feature-branch staging stage — so an aws-main build triggered two staging deploys in the same run.

This adds a dedicated `Deploy aws-staging` stage gated on the aws-main branch. It authenticates as jenkins-openvsx (the same identity the aws-production stage already uses) and runs helm-deploy against eks-staging. The feature-branch staging stage no longer fires on aws-main, so the double deploy is gone.

jenkins-openvsx has been granted cluster-admin on eks-staging for now; this will be folded into the eks/ module in tf-resources when the staging cluster is recreated from Terraform.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>