### PR TITLE
ci: add dedicated aws-staging deploy stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,24 +93,6 @@ pipeline {
       }
     }
 
-    stage('Deploy to EKS staging environment') {
-      when {
-        anyOf {
-        expression { return env.BRANCH_NAME.startsWith('feature') }
-        branch 'aws-main'
-      }
-      }
-      steps {
-        container('eks') {
-          withKubeConfig([credentialsId: 'ci-bot-eks-staging-token', serverUrl: 'https://5CF0970816FA7A7C340E6BEF8575A8D4.gr7.eu-central-1.eks.amazonaws.com']) {
-            sh '''
-              ./kubernetes/helm-deploy.sh aws-staging "${IMAGE_TAG}"
-            '''
-          }
-        }
-      }
-    }
-
     stage('Deploy test') {
       when {
         branch 'test'
@@ -150,6 +132,28 @@ pipeline {
           withKubeConfig([credentialsId: 'ci-bot-okd-c1-token', serverUrl: 'https://api.okd-c1.eclipse.org:6443']) {
             sh '''
               ./kubernetes/helm-deploy.sh production "${IMAGE_TAG}"
+            '''
+          }
+        }
+      }
+    }
+
+    stage('Deploy aws-staging') {
+      when {
+        branch 'aws-main'
+      }
+      steps {
+        container('eks') {
+          withCredentials([
+            string(credentialsId: 'jenkins-openvsx-aws-key-id',     variable: 'AWS_ACCESS_KEY_ID'),
+            string(credentialsId: 'jenkins-openvsx-aws-secret-key', variable: 'AWS_SECRET_ACCESS_KEY'),
+          ]) {
+            sh '''
+              set -e
+              export AWS_DEFAULT_REGION=eu-central-1
+              export KUBECONFIG="${HOME}/.kube/config"
+              aws eks update-kubeconfig --name eks-staging --region eu-central-1
+              ./kubernetes/helm-deploy.sh aws-staging "${IMAGE_TAG}"
             '''
           }
         }


### PR DESCRIPTION
Keeps the aws-production branch's Jenkinsfile in sync with the aws-staging deploy stage being added on aws-main.

The new `Deploy aws-staging` stage is gated on the aws-main branch, so it stays dormant on aws-production — this carries no functional change to aws-production deploys. It only keeps the pipeline definition consistent across the two deploy branches.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>