### PR TITLE
fix(chart): yara-rules PVC ReadWriteOnce

### DIFF
--- a/charts/openvsx/templates/yara-rest/pvc.yaml
+++ b/charts/openvsx/templates/yara-rest/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: yara-rules
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 2Gi


### PR DESCRIPTION
The aws-staging deploy fails at `helm upgrade` trying to patch the `yara-rules` PVC from ReadWriteOnce to ReadWriteMany:

```
cannot patch "yara-rules" with kind PersistentVolumeClaim: ... spec is immutable after creation
```


This sets the PVC back to ReadWriteOnce so the rendered spec matches the live PVC and the upgrade can proceed.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>