### PR TITLE
fix(keda): scope TriggerAuthentication secret to environment

### DIFF
--- a/charts/openvsx/templates/keda-auth.yaml
+++ b/charts/openvsx/templates/keda-auth.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   secretTargetRef:
   - parameter: username
-    name: grafana-cloud-secret-production
+    name: grafana-cloud-secret-{{ .Values.environment }}
     key: PROMETHEUS_USERNAME
   - parameter: password
-    name: grafana-cloud-secret-production
+    name: grafana-cloud-secret-{{ .Values.environment }}
     key: PROMETHEUS_PASSWORD
 {{- end }}

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -18,8 +18,9 @@ autoscaling:
 keda:
   enabled: true
   clusterName: eks-staging
-  minReplicas: 12
-  maxReplicas: 18
+  minReplicas: 1
+  maxReplicas: 4
+  thresholdBusyRatio: "0.5"
   prometheusAddress: "https://prometheus-prod-32-prod-ca-east-0.grafana.net/api/prom"
   pollingInterval: 30
   cooldownPeriod: 600


### PR DESCRIPTION
Two staging KEDA fixes.

**Auth:** `keda-auth.yaml` hardcoded the secret name `grafana-cloud-secret-production`, so on staging KEDA couldn't authenticate to Grafana Cloud Prometheus (the staging secret is `grafana-cloud-secret-staging`) and no HPA was created — the app stayed pinned at one replica. Now uses `grafana-cloud-secret-{{ .Values.environment }}`, matching what `deployment.yaml` already does. Renders the staging secret on staging, production secret on production (unchanged).

**Scaling bounds:** staging had `minReplicas: 12 / maxReplicas: 18` (a floor higher than production's 8) and no threshold override (default 0.75). Once auth works the ScaledObject would have immediately scaled staging 1 → 12 pods. Set to `1 / 4` with `thresholdBusyRatio: 0.5` — sane bounds for a low-traffic test environment.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>