### PR TITLE
Wire app chart + CI to the new EKS staging cluster (eks-staging-openvsx)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,7 +151,7 @@ pipeline {
               set -e
               export AWS_DEFAULT_REGION=eu-central-1
               export KUBECONFIG="${HOME}/.kube/config"
-              aws eks update-kubeconfig --name eks-staging --region eu-central-1
+              aws eks update-kubeconfig --name eks-staging-openvsx --region eu-central-1
               ./kubernetes/helm-deploy.sh aws-staging "${IMAGE_TAG}"
             '''
           }

--- a/charts/openvsx/templates/deployment.yaml
+++ b/charts/openvsx/templates/deployment.yaml
@@ -53,6 +53,15 @@ spec:
           value: {{ .Values.environment }}
         - name: JVM_ARGS
           value: {{ .Values.website.jvmArgs }}
+        {{- if .Values.externalSecrets.inClusterPostgres }}
+        # In-cluster postgresql-ha: password is chart-generated, injected here and
+        # overrides spring.datasource.password from the ESO-composed configuration.yml.
+        - name: SPRING_DATASOURCE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.inClusterPostgres.passwordSecret.name }}
+              key: {{ .Values.inClusterPostgres.passwordSecret.key }}
+        {{- end }}
         volumeMounts:
         - name: deployment-configuration
           mountPath: /run/secrets/open-vsx.org/deployment

--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -60,7 +60,7 @@ spec:
             data:
               redis:
                 cluster:
-                  nodes: "{{ "{{" }} .redis_endpoint {{ "}}" }}:6380"
+                  nodes: "{{ "{{" }} .redis_endpoint {{ "}}" }}:6379"
                 password: "{{ "{{" }} .redis_auth_token {{ "}}" }}"
                 ssl:
                   enabled: true

--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -1,16 +1,22 @@
 {{- if .Values.externalSecrets.enabled }}
+{{- $env := .Values.environment }}
 # Syncs AWS Secrets Manager → K8s secrets. Requires ESO + ClusterSecretStore "aws-secrets-manager".
-# Enabled on EKS (values-aws.yaml); disabled on OKD (values.yaml).
-# deployment-configuration-production is composed directly from individual SM secrets — no intermediate SM secret needed.
+# Enabled on EKS (values-aws.yaml / values-aws-staging.yaml); disabled on OKD (values.yaml).
+# deployment-configuration-<env> is composed directly from individual SM secrets — no intermediate SM secret needed.
 
-# ── deployment-configuration-production ──────────────────────────────────────
+# ── deployment-configuration-<env> ───────────────────────────────────────────
 # ESO reads individual fields from rds/, elasticache/, oauth, elasticsearch SM secrets
 # and composes the Spring Boot configuration.yml in-cluster. No terraform apply needed
 # when upstream credentials change — ESO recomposes on the next refreshInterval.
+#
+# Datasource:
+#   - production: AWS RDS (externalSecrets.inClusterPostgres unset/false) — pulls rds_* from SM.
+#   - staging:    in-cluster postgresql-ha (externalSecrets.inClusterPostgres: true) — points at
+#                 the repmgr primary service; DB creds come from the Bitnami chart secret, NOT SM.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: deployment-configuration-production
+  name: deployment-configuration-{{ $env }}
   namespace: {{ .Values.namespace }}
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
@@ -18,7 +24,7 @@ spec:
     kind: ClusterSecretStore
     name: {{ .Values.externalSecrets.clusterSecretStore }}
   target:
-    name: deployment-configuration-production
+    name: deployment-configuration-{{ $env }}
     creationPolicy: Owner
     template:
       engineVersion: v2
@@ -31,15 +37,26 @@ spec:
           server:
             forward-headers-strategy: native
           management:
+            {{- if eq $env "staging" }}
+            # Staging observability is METRICS-ONLY
+            tracing:
+              enabled: false
+            {{- else }}
             zipkin:
               tracing:
                 # EKS-specific: Alloy runs in monitoring ns (vs OKD's grafana-alloy-production in open-vsx-org).
                 endpoint: "http://grafana-alloy.monitoring.svc.cluster.local:9411/api/v2/spans"
+            {{- end }}
           spring:
             datasource:
+              {{- if .Values.externalSecrets.inClusterPostgres }}
+              url: "jdbc:postgresql://{{ .Values.externalSecrets.postgresHost }}:5432/{{ .Values.externalSecrets.postgresDb }}"
+              username: "{{ .Values.externalSecrets.postgresUsername | default "postgres" }}"
+              {{- else }}
               url: "jdbc:postgresql://{{ "{{" }} .rds_endpoint {{ "}}" }}/{{ "{{" }} .rds_db_name {{ "}}" }}?sslmode=require"
               username: "{{ "{{" }} .rds_username {{ "}}" }}"
               password: "{{ "{{" }} .rds_password {{ "}}" }}"
+              {{- end }}
             data:
               redis:
                 cluster:
@@ -73,7 +90,7 @@ spec:
                     # redirect-uri varies per environment (open-vsx.org vs staging.open-vsx.org).
                     # client-id/secret + scope come from application.yml.
                     eclipse:
-                      redirect-uri: "https://open-vsx.org/login/oauth2/code/eclipse"
+                      redirect-uri: "https://{{ .Values.host }}/login/oauth2/code/eclipse"
                       client-id: "{{ "{{" }} .eclipse_client_id {{ "}}" }}"
                       client-secret: "{{ "{{" }} .eclipse_client_secret {{ "}}" }}"
                     github:
@@ -82,78 +99,79 @@ spec:
           ovsx:
             elasticsearch:
               # host is env-specific (ECK uses elasticsearch-<env>-es-http); truststore/password not in application.yml.
-              host: "elasticsearch-production-es-http:9200"
+              host: "elasticsearch-{{ $env }}-es-http:9200"
               username: "elastic"
               password: "{{ "{{" }} .es_password {{ "}}" }}"
               truststore: "/run/secrets/open-vsx.org/truststore/elasticsearch-http-certs.keystore"
               truststorePassword: "changeit"
+              clear_on_start: {{ .Values.externalSecrets.elasticsearchClearOnStart }}
             logs:
               # Fastly access logs — bucket name differs per env (fastlyopenvsxorg/-staging/-test).
               aws:
-                bucket: "fastlyopenvsxorg"
+                bucket: {{ .Values.externalSecrets.fastlyLogsBucket | default "fastlyopenvsxorg" | quote }}
                 format: "fastly"
                 log-location-prefix: "FastlyLogs/"
                 max-keys: 1000
                 region: "eu-central-1"
             storage:
-              # Bucket varies per env (eclipse-openvsx-test pre-cutover → openvsxorg post-cutover);
-              # static AWS keys removed — IRSA via ServiceAccount provides credentials.
               aws:
-                bucket: "eclipse-openvsx-test"
+                bucket: {{ .Values.externalSecrets.storageBucket | default "openvsxorg" | quote }}
                 region: "eu-central-1"
   data:
+    {{- if not .Values.externalSecrets.inClusterPostgres }}
     - secretKey: rds_endpoint
       remoteRef:
-        key: openvsx/production/rds
+        key: openvsx/{{ $env }}/rds
         property: endpoint
     - secretKey: rds_db_name
       remoteRef:
-        key: openvsx/production/rds
+        key: openvsx/{{ $env }}/rds
         property: db_name
     - secretKey: rds_username
       remoteRef:
-        key: openvsx/production/rds
+        key: openvsx/{{ $env }}/rds
         property: username
     - secretKey: rds_password
       remoteRef:
-        key: openvsx/production/rds
+        key: openvsx/{{ $env }}/rds
         property: password
+    {{- end }}
     - secretKey: redis_endpoint
       remoteRef:
-        key: openvsx/production/elasticache
+        key: openvsx/{{ $env }}/elasticache
         property: endpoint
     - secretKey: redis_auth_token
       remoteRef:
-        key: openvsx/production/elasticache
+        key: openvsx/{{ $env }}/elasticache
         property: auth_token
     - secretKey: es_password
       remoteRef:
-        key: openvsx/production/elasticsearch
+        key: openvsx/{{ $env }}/elasticsearch
         property: password
     - secretKey: eclipse_client_id
       remoteRef:
-        key: openvsx/production/oauth
+        key: openvsx/{{ $env }}/oauth
         property: eclipse_client_id
     - secretKey: eclipse_client_secret
       remoteRef:
-        key: openvsx/production/oauth
+        key: openvsx/{{ $env }}/oauth
         property: eclipse_client_secret
     - secretKey: github_client_id
       remoteRef:
-        key: openvsx/production/oauth
+        key: openvsx/{{ $env }}/oauth
         property: github_client_id
     - secretKey: github_client_secret
       remoteRef:
-        key: openvsx/production/oauth
+        key: openvsx/{{ $env }}/oauth
         property: github_client_secret
 ---
-# ── grafana-cloud-secret-production ──────────────────────────────────────────
+# ── grafana-cloud-secret-<env> ───────────────────────────────────────────────
 # SM keys match K8s keys exactly — dataFrom.extract maps them 1:1.
 # bootstrap-secrets.sh stores per-service credentials (separate username/password per datasource).
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: grafana-cloud-secret-production
+  name: grafana-cloud-secret-{{ $env }}
   namespace: {{ .Values.namespace }}
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
@@ -161,17 +179,17 @@ spec:
     kind: ClusterSecretStore
     name: {{ .Values.externalSecrets.clusterSecretStore }}
   target:
-    name: grafana-cloud-secret-production
+    name: grafana-cloud-secret-{{ $env }}
     creationPolicy: Owner
   dataFrom:
     - extract:
-        key: openvsx/production/grafana-cloud
+        key: openvsx/{{ $env }}/grafana-cloud
 ---
-# ── deployment-configuration-production-argus ─────────────────────────────────
+# ── deployment-configuration-<env>-argus ─────────────────────────────────────
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: deployment-configuration-production-argus
+  name: deployment-configuration-{{ $env }}-argus
   namespace: {{ .Values.namespace }}
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
@@ -179,9 +197,9 @@ spec:
     kind: ClusterSecretStore
     name: {{ .Values.externalSecrets.clusterSecretStore }}
   target:
-    name: deployment-configuration-production-argus
+    name: deployment-configuration-{{ $env }}-argus
     creationPolicy: Owner
   dataFrom:
     - extract:
-        key: openvsx/production/argus
+        key: openvsx/{{ $env }}/argus
 {{- end }}

--- a/charts/openvsx/templates/grafana-alloy.yaml
+++ b/charts/openvsx/templates/grafana-alloy.yaml
@@ -1,4 +1,4 @@
-{{- if not (and .Values.eks.enabled (eq .Values.environment "production")) }}
+{{- if .Values.alloy.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/openvsx/templates/redis-cluster-operator/deployment.yaml
+++ b/charts/openvsx/templates/redis-cluster-operator/deployment.yaml
@@ -1,4 +1,5 @@
-{{- if not (and .Values.eks.enabled (eq .Values.environment "production")) }}
+{{- /* redis-cluster-operator only on OKD. Both EKS envs use ElastiCache. */}}
+{{- if not .Values.eks.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/openvsx/templates/redis-cluster-operator/rbac.yaml
+++ b/charts/openvsx/templates/redis-cluster-operator/rbac.yaml
@@ -1,4 +1,5 @@
-{{- if not (and .Values.eks.enabled (eq .Values.environment "production")) }}
+{{- /* redis-cluster-operator RBAC only on OKD. Both EKS envs use ElastiCache. */}}
+{{- if not .Values.eks.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/openvsx/templates/redis-cluster.yaml
+++ b/charts/openvsx/templates/redis-cluster.yaml
@@ -1,4 +1,5 @@
-{{- if not (and .Values.eks.enabled (eq .Values.environment "production")) }}
+{{- /* In-cluster Redis (operator + CR) only on OKD. Both EKS envs use ElastiCache. */}}
+{{- if not .Values.eks.enabled }}
 apiVersion: open-vsx.org/v1
 kind: RedisCluster
 metadata:

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -17,7 +17,7 @@ autoscaling:
 
 keda:
   enabled: true
-  clusterName: eks-staging
+  clusterName: eks-staging-openvsx
   minReplicas: 1
   maxReplicas: 4
   thresholdBusyRatio: "0.5"
@@ -42,29 +42,39 @@ image:
 eks:
   enabled: true  # Switch to false for OKD installations
 
-# kube-state-metrics + node-exporter are deployed by EKS Observability (enabled
-# in the AWS console for eks-staging). The two platform ServiceMonitors below
-# point the in-chart Alloy at those services. eks-production has EKS Observability
-# disabled, so values-aws.yaml sets this to false (when/if that file is introduced).
+# ── ServiceAccount (IRSA) — replaces the manual `default` SA + static AWS keys ──
+serviceAccount:
+  create: true
+  name: openvsx
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::365555376529:role/openvsx-app-staging"
+
+# ── External Secrets Operator — composes deployment-configuration-staging from SM ──
+externalSecrets:
+  enabled: true
+  clusterSecretStore: aws-secrets-manager
+  refreshInterval: 1h
+  fastlyLogsBucket: "fastlyopenvsxorgstaging"
+  storageBucket: "openvsxorgstaging"
+  elasticsearchClearOnStart: true
+  # In-cluster Postgres (no RDS in staging)
+  inClusterPostgres: true
+  postgresHost: "staging-postgresql-ha-postgresql"
+  postgresDb: "openvsx-staging"
+  postgresUsername: "postgres"
+
+# Injects SPRING_DATASOURCE_PASSWORD from the Bitnami-generated postgresql-ha secret.
+inClusterPostgres:
+  passwordSecret:
+    name: "staging-postgresql-ha-postgresql"
+    key: "password"
+
 serviceMonitors:
   platformMetrics:
     enabled: true
 
 aws-load-balancer-controller:
-  enabled: true
-  resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 200m
-    memory: 256Mi
-  clusterName: eks-staging
-  region: eu-central-1
-  vpcId: vpc-0285cbfe9bfb7e4fd
-  serviceAccount:
-    create: false
-    name: aws-load-balancer-controller-staging
+  enabled: false
 
 ingress:
   certArn: arn:aws:acm:eu-central-1:365555376529:certificate/c247a8c7-31fa-4116-bd4a-c1e5aebad840
@@ -195,84 +205,9 @@ postgresql-ha:
   pgpool:
     replicaCount: 0
 
-# redis
-redis:
-  master:
-    pdb:
-      create: true
-      minAvailable: 1
-    podAnnotations:
-      "karpenter.sh/do-not-disrupt": "true"
-      "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
-  replica:
-    pdb:
-      create: true
-      minAvailable: 1
-    podAnnotations:
-      "karpenter.sh/do-not-disrupt": "true"
-      "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
-  name: redis
-  replicas: 6
-  image:
-    repository: redis
-    tag: "7.2.10"
-    pullPolicy: IfNotPresent
-  maxmemory: "896mb"
-  resources:
-    requests:
-      memory: "512Mi"
-      cpu: "250m"
-    limits:
-      memory: "1536Mi"
-      cpu: "500m"
-  persistence:
-    storageGi: 5
-    storageClass: "gp3"
-  serviceAccountName: redis-cluster-operator
-  clusterRoleName: redis-cluster-operator-role-cluster
-  clusterRoleBindingName:  redis-cluster-operator-role-binding-cluster
-  roleName: redis-cluster-operator-role
-  roleBinding: redis-cluster-operator-role-binding
-
 # grafana alloy
 alloy:
-  alloy:
-    clustering:
-      enabled: true
-    configMap:
-      create: false
-      name: "grafana-alloy-configmap-staging"
-      key: "config.river"
-    envFrom:
-      - secretRef:
-          name: grafana-cloud-secret-staging
-      - secretRef:
-          name: redis-secret-staging
-    extraEnv:
-    - name: CLUSTER_NAME
-      value: "eks-staging"
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
-    extraPorts:
-      - name: zipkin
-        port: 9411
-        targetPort: 9411
-      - name: loki
-        port: 3100
-        targetPort: 3100
-  crds:
-    create: true
-  controller:
-    type: "daemonset"
-    podLabels:
-      app: *name
-      environment: *environment
-    nodeSelector:
-      openvsx-production-alloy: null
-  fullnameOverride: grafana-alloy-staging
-  namespaceOverride: *namespace
+  enabled: false
 
 clamav:
   enabled: true


### PR DESCRIPTION
Wires the chart to the new Terraform-built EKS staging cluster (eks-staging-openvsx) and points the aws-main deploy at it.

- Staging infra wiring: ElastiCache (cluster-mode Valkey, TLS+auth), openvsx-app-staging IRSA (drops static AWS keys), ESO from openvsx/staging/*, in-cluster postgresql-ha (no RDS), in-chart Alloy off (metrics+logs ship via the tf-resources monitoring module).
- KEDA: clusterName eks-staging-openvsx, minReplicas 1 / maxReplicas 4, thresholdBusyRatio 0.5.
- Fix in-cluster Postgres password secret key (password, not postgres-password) so the app can start.
- Jenkinsfile: aws-staging stage now deploys to eks-staging-openvsx (retires the hand-built eks-staging).

Staging-only: aws-main carries values-aws-staging.yaml (no prod values) and the prod stages stay gated to aws-production/production — verified prod rendering is unaffected.

After merge, the first aws-main build creates the open-vsx-org-staging namespace; then run scripts/bootstrap-es-password.sh staging to set the real ES password.