### PR TITLE
fix(staging): postgresql-ha volume permissions so Postgres starts on fresh EKS staging volumes

### DIFF
--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -142,6 +142,13 @@ es:
 
 postgresql-ha:
   enabled: true
+  # Root init container pre-creates /bitnami/postgresql/conf owned by 1001 before the conf.d submount.
+  # On fresh volumes fsGroup misses that kubelet-created parent dir → postgres permission-denied crashloop.
+  volumePermissions:
+    enabled: true
+    image:
+      repository: bitnamilegacy/os-shell  # public bitnami/os-shell is retired
+      tag: 12-debian-12-r51
   metrics:
     enabled: true
     image:


### PR DESCRIPTION
After the previous PR deployed to the new EKS staging cluster (`eks-staging-openvsx`), all three `postgresql-ha` pods crashloop on first boot, before Postgres starts:

```
cp: cannot create regular file '/bitnami/postgresql/conf/postgresql.conf': Permission denied
```

The `extendedConf` block mounts a configMap at `/bitnami/postgresql/conf/conf.d/`, so on a fresh volume the kubelet pre-creates the parent `/bitnami/postgresql/conf` as `root:root` *after* fsGroup has run. The non-root container (UID 1001, read-only rootfs) then can't write the generated `postgresql.conf` there. The chart and pod spec are identical to the old hand-built cluster — that one only survives because its volumes were initialized earlier and the dir persists; a fresh deploy reproduces the crash.

Enabling `postgresql-ha.volumePermissions` adds the chart's `init-chmod-data` init container, which `mkdir`s and chowns that dir to 1001 before the submount is set up — the chart's intended remedy. The `os-shell` image is pinned to `bitnamilegacy` since the public `bitnami/*` images are retired.

Staging-only; no production values touched.
