### PR TITLE
fix(staging): connect to Postgres primary via multi-host JDBC URL (targetServerType=primary)

### DIFF
--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -50,7 +50,15 @@ spec:
           spring:
             datasource:
               {{- if .Values.externalSecrets.inClusterPostgres }}
-              url: "jdbc:postgresql://{{ .Values.externalSecrets.postgresHost }}:5432/{{ .Values.externalSecrets.postgresDb }}"
+              {{- $h := .Values.externalSecrets.postgresHost }}
+              {{- $n := int (.Values.externalSecrets.postgresReplicas | default 3) }}
+              {{- $hosts := list }}
+              {{- range $i := until $n }}
+              {{- $hosts = append $hosts (printf "%s-%d.%s-headless.%s.svc.cluster.local:5432" $h $i $h $.Values.namespace) }}
+              {{- end }}
+              # Multi-host list + targetServerType=primary: pgjdbc probes each repmgr pod and connects to the
+              # read-write primary (survives failover). pgpool is disabled; the round-robin svc hits standbys.
+              url: "jdbc:postgresql://{{ join "," $hosts }}/{{ .Values.externalSecrets.postgresDb }}?targetServerType=primary"
               username: "{{ .Values.externalSecrets.postgresUsername | default "postgres" }}"
               {{- else }}
               url: "jdbc:postgresql://{{ "{{" }} .rds_endpoint {{ "}}" }}/{{ "{{" }} .rds_db_name {{ "}}" }}?sslmode=require"


### PR DESCRIPTION
With Postgres now starting (after the volumePermissions fix in #11242), the app gets further but still can't boot:

```
org.postgresql.util.PSQLException: ERROR: cannot execute CREATE TABLE in a read-only transaction
```

The in-cluster datasource URL was built from a single host — `jdbc:postgresql://staging-postgresql-ha-postgresql:5432/...` — which is the Bitnami multi-node service that round-robins across the primary *and* the two read-only standbys. When the connection lands on a standby, Flyway's `CREATE TABLE` fails and the Spring context dies.

pgpool is disabled (`replicaCount: 0`) on both the new and the old cluster, so it isn't the write-router. The old (working) cluster instead lists the three repmgr pod FQDNs via the headless service with `?targetServerType=primary`, which makes the JDBC driver itself probe the nodes and connect only to the read-write primary — and re-probe after a failover.

This change makes the in-cluster branch of `external-secrets.yaml` render the same multi-host primary-targeting URL, parameterised by `postgresReplicas` (default 3). Rendered output matches the old cluster exactly. Only the `inClusterPostgres` branch is touched; the RDS branch is unchanged, so production is unaffected.
