### PR TITLE
fix(staging): pin postgresql-ha passwords via existingSecret (ESO ← Secrets Manager)

### DIFF
--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -210,4 +210,57 @@ spec:
   dataFrom:
     - extract:
         key: openvsx/{{ $env }}/argus
+{{- if .Values.externalSecrets.inClusterPostgres }}
+---
+# ── postgresql-ha credentials (staging in-cluster Postgres only) ──────────────
+# Pins Bitnami postgresql-ha passwords to SM so an --atomic uninstall-on-failure can't
+# regenerate them out of sync with the persisted PGDATA. Key names MUST match the
+# postgresql-ha 16.3.2 existingSecret / pgpool.existingSecret contract exactly.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: staging-postgresql-ha-postgresql
+  namespace: {{ .Values.namespace }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.externalSecrets.clusterSecretStore }}
+  target:
+    name: staging-postgresql-ha-postgresql
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: openvsx/{{ $env }}/postgresql
+        property: password
+    - secretKey: repmgr-password
+      remoteRef:
+        key: openvsx/{{ $env }}/postgresql
+        property: repmgr-password
+---
+# sr-check-password is mounted on the postgresql pods even with pgpool replicaCount 0.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: staging-postgresql-ha-pgpool
+  namespace: {{ .Values.namespace }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.externalSecrets.clusterSecretStore }}
+  target:
+    name: staging-postgresql-ha-pgpool
+    creationPolicy: Owner
+  data:
+    - secretKey: admin-password
+      remoteRef:
+        key: openvsx/{{ $env }}/postgresql
+        property: admin-password
+    - secretKey: sr-check-password
+      remoteRef:
+        key: openvsx/{{ $env }}/postgresql
+        property: sr-check-password
+{{- end }}
 {{- end }}

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -168,6 +168,9 @@ postgresql-ha:
         app: open-vsx-org
         environment: staging
   postgresql:
+    # Pinned to SM via ESO (templates/external-secrets.yaml) — stops the --atomic
+    # uninstall password-regeneration loop. Keys: password, repmgr-password.
+    existingSecret: staging-postgresql-ha-postgresql
     image:
       repository: bitnamilegacy/postgresql-repmgr
       tag: 17.6.0-debian-12-r2
@@ -211,6 +214,9 @@ postgresql-ha:
       "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
   pgpool:
     replicaCount: 0
+    # sr-check-password is mounted on the postgresql pods even at replicaCount 0; pin it too.
+    # Keys: admin-password, sr-check-password.
+    existingSecret: staging-postgresql-ha-pgpool
 
 # grafana alloy
 alloy:


### PR DESCRIPTION
## Problem

Bitnami `postgresql-ha` auto-generates its passwords (`password`/`repmgr-password` and the pgpool `admin-password`/`sr-check-password`) and stores them **only** in helm-managed secrets. Our deploys run `helm upgrade --install --atomic`; on a first-install failure `--atomic` does a full `helm uninstall`, deleting those secrets — while the PVCs persist. The next install mints **new** random passwords that no longer match the already-initialized PGDATA, so `repmgr` auth fails and Postgres crashloops (`FATAL: password authentication failed for user "repmgr"`). This recurs on any fresh cluster whose first deploy doesn't succeed on the first try.

Note the postgresql StatefulSet mounts `sr-check-password` from the **pgpool** secret even though pgpool is `replicaCount: 0`, so both secrets have to be pinned — pinning only the main one half-closes the loop.

## Fix

Pin both secrets to a TF-owned Secrets Manager secret `openvsx/staging/postgresql`, synced into K8s by ESO, and point the chart at them via `postgresql.existingSecret` + `pgpool.existingSecret`. With `existingSecret` set, the chart no longer generates the secrets (verified: both subchart `secrets.yaml` render empty), and the StatefulSet mounts password files from the ESO-synced secrets. Keys match the 16.3.2 `existingSecret` contract for `username: postgres` (`password`, `repmgr-password`, `admin-password`, `sr-check-password` — no `postgres-password`).

The app's own datasource consumer (`inClusterPostgres.passwordSecret`) already points at `staging-postgresql-ha-postgresql` / key `password`, so it reads the synced secret transparently — no change there.

## Deploy ordering (important)

This depends on a companion Terraform change that creates `openvsx/staging/postgresql` in Secrets Manager. **Apply that first**, then merge this. After deploy, the existing PG PVCs (initialized against the old random passwords) must be wiped once so PGDATA reinitializes against the pinned secret — no real data yet (`migrate-staging-db.sh` not run).

Staging-only; the `inClusterPostgres` gate means production (RDS) is untouched.
