### PR TITLE
fix(staging): read ES elastic password from the ECK secret (retire SM round-trip + bootstrap script)

### DIFF
--- a/charts/openvsx/templates/deployment.yaml
+++ b/charts/openvsx/templates/deployment.yaml
@@ -62,6 +62,16 @@ spec:
               name: {{ .Values.inClusterPostgres.passwordSecret.name }}
               key: {{ .Values.inClusterPostgres.passwordSecret.key }}
         {{- end }}
+        {{- if .Values.externalSecrets.elasticsearchPasswordFromEck }}
+        # In-cluster ECK Elasticsearch: read the elastic password straight from the ECK-managed
+        # secret (the source of truth), overriding ovsx.elasticsearch.password from configuration.yml.
+        # No SM round-trip / bootstrap script; self-heals if ECK rotates the password.
+        - name: OVSX_ELASTICSEARCH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: elasticsearch-{{ .Values.environment }}-es-elastic-user
+              key: elastic
+        {{- end }}
         volumeMounts:
         - name: deployment-configuration
           mountPath: /run/secrets/open-vsx.org/deployment

--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -109,7 +109,9 @@ spec:
               # host is env-specific (ECK uses elasticsearch-<env>-es-http); truststore/password not in application.yml.
               host: "elasticsearch-{{ $env }}-es-http:9200"
               username: "elastic"
+              {{- if not .Values.externalSecrets.elasticsearchPasswordFromEck }}
               password: "{{ "{{" }} .es_password {{ "}}" }}"
+              {{- end }}
               truststore: "/run/secrets/open-vsx.org/truststore/elasticsearch-http-certs.keystore"
               truststorePassword: "changeit"
               clear_on_start: {{ .Values.externalSecrets.elasticsearchClearOnStart }}
@@ -152,10 +154,12 @@ spec:
       remoteRef:
         key: openvsx/{{ $env }}/elasticache
         property: auth_token
+    {{- if not .Values.externalSecrets.elasticsearchPasswordFromEck }}
     - secretKey: es_password
       remoteRef:
         key: openvsx/{{ $env }}/elasticsearch
         property: password
+    {{- end }}
     - secretKey: eclipse_client_id
       remoteRef:
         key: openvsx/{{ $env }}/oauth

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -57,6 +57,9 @@ externalSecrets:
   fastlyLogsBucket: "fastlyopenvsxorgstaging"
   storageBucket: "openvsxorgstaging"
   elasticsearchClearOnStart: true
+  # Read the ES elastic password straight from the ECK secret (deployment.yaml) instead of SM/ESO —
+  # app comes up green on first deploy, no bootstrap script, self-heals on ECK password rotation.
+  elasticsearchPasswordFromEck: true
   # In-cluster Postgres (no RDS in staging)
   inClusterPostgres: true
   postgresHost: "staging-postgresql-ha-postgresql"


### PR DESCRIPTION
## Problem

The staging app authenticates to ECK Elasticsearch as `elastic`, whose password ECK generates and stores in `elasticsearch-staging-es-elastic-user`. The chart instead read the password from a *separate* copy in Secrets Manager (`openvsx/staging/elasticsearch`), kept in sync by the manual `bootstrap-es-password.sh` script. That created three problems:

- A manual post-deploy step on every fresh deploy.
- Two sources of truth that drift — ECK regenerates the password on any ES redeploy, so the SM copy goes stale.
- A deploy deadlock: the app can't reach Ready until the password is bootstrapped, but bootstrap needs ES running, and `helm --atomic` tears the whole release (including ES) down when the app isn't Ready in time.

## Fix

Read the password straight from the ECK secret — the in-cluster source of truth — exactly like the chart already does for the in-cluster Postgres password. `deployment.yaml` injects `OVSX_ELASTICSEARCH_PASSWORD` (relaxed-binds to `ovsx.elasticsearch.password`, and env overrides the imported `configuration.yml`) via `secretKeyRef` from `elasticsearch-<env>-es-elastic-user`. The SM `es_password` read and the composed `password:` line are dropped.

Result: the app authenticates on first boot, comes up green under `--atomic` (no rollback, no deadlock), needs no bootstrap script, and self-heals if ECK ever rotates the password (restart picks up the new value).

Verified that `configuration.yml` is loaded via `spring.config.import` (`application.yml:35`), so the env var reliably overrides it — the same mechanism the Postgres injection relies on.

## Scope

Gated behind `externalSecrets.elasticsearchPasswordFromEck`, set only in `values-aws-staging.yaml`. With the flag off (OKD, and prod values when created) the existing SM path is untouched — verified by rendering both states. `bootstrap-es-password.sh` is now unnecessary for staging; it can be retired once prod adopts the same flag.
