### PR TITLE
fix(eks): route loki4j log push through the monitoring-ns Alloy

### DIFF
--- a/charts/openvsx/templates/deployment.yaml
+++ b/charts/openvsx/templates/deployment.yaml
@@ -51,6 +51,12 @@ spec:
           value: /run/secrets/open-vsx.org/deployment/configuration.yml
         - name: ENVNAME
           value: {{ .Values.environment }}
+        {{- if .Values.eks.enabled }}
+        # EKS: route Loki4jAppender push through cluster-wide Alloy in monitoring ns
+        # (chart Alloy is disabled — see values-aws.yaml). Overrides LOKI_URL from envFrom.
+        - name: LOKI_URL
+          value: "http://grafana-alloy.monitoring.svc.cluster.local:3100/loki/api/v1/push"
+        {{- end }}
         - name: JVM_ARGS
           value: {{ .Values.website.jvmArgs }}
         {{- if .Values.externalSecrets.inClusterPostgres }}

--- a/configuration/logback-spring.xml
+++ b/configuration/logback-spring.xml
@@ -7,7 +7,11 @@
         <verbose>true</verbose>
         <batchMaxBytes>65536</batchMaxBytes>
         <http>
-            <url>http://grafana-alloy-${ENVNAME}:3100/loki/api/v1/push</url>
+            <url>${LOKI_URL}</url>
+            <auth>
+                <username>${LOKI_USERNAME}</username>
+                <password>${LOKI_PASSWORD}</password>
+            </auth>
             <requestTimeoutMs>15000</requestTimeoutMs>
         </http>
         <format>


### PR DESCRIPTION
On EKS the bundled chart Alloy is disabled (`alloy.enabled: false`), so the openvsx-server Loki4jAppender pointed at the in-namespace `grafana-alloy-<env>:3100` Service that EKS never creates — producing `java.net.ConnectException` on the new staging cluster.

This routes the appender to the cluster-wide Alloy in the `monitoring` namespace (`grafana-alloy.monitoring.svc.cluster.local:3100`) via a `LOKI_URL` env gated on `eks.enabled`, matching the pattern already on `aws-production`. Non-EKS installs fall through to `LOKI_URL` from the `grafana-cloud` secret, so OKD/test behaviour is unchanged.

Pairs with the tf-resources MR that adds the matching `:3100` receiver to the staging Alloy.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>