### PR TITLE
fix: parameterize Elasticsearch version per environment

### DIFF
--- a/charts/openvsx/templates/elasticsearch.yaml
+++ b/charts/openvsx/templates/elasticsearch.yaml
@@ -57,4 +57,4 @@ spec:
           name: elasticsearch
           resources:
           {{- toYaml .Values.es.resources | nindent 12 }}
-  version: 9.2.8
+  version: {{ .Values.es.version }}

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -129,6 +129,8 @@ resources:
 
 # elastic search
 es:
+  # Spring Boot 4 bundles the 9.x ES Java client, which cannot talk to an 8.x server.
+  version: "9.2.8"
   podAnnotations:
     "karpenter.sh/do-not-disrupt": "true"
     "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
@@ -141,7 +143,7 @@ es:
       cpu: 1
       memory: 8Gi
   storage_class: gp3
-  storage: 1Gi
+  storage: 4Gi
 
 postgresql-ha:
   enabled: true

--- a/charts/openvsx/values.yaml
+++ b/charts/openvsx/values.yaml
@@ -85,6 +85,8 @@ resources:
 
 # elastic search
 es:
+  # Default ES version for all envs; override per-env. Prod stays 8.18.8 until its own snapshot-gated 8.19->9.2 upgrade.
+  version: "8.18.8"
   java_opts: -Xms4g -Xmx4g -Dlog4j2.formatMsgNoLookups=true
   resources:
     limits:


### PR DESCRIPTION
### What
Replaces the hardcoded Elasticsearch `version` in `templates/elasticsearch.yaml` with a per-environment `es.version` value. Staging stays on **9.2.8** (and grows its disk 1Gi → 4Gi); production, test and okd-staging default to **8.18.8**.

### Why
The Spring Boot 4 upgrade requires ES 9.x (its bundled 9.x Java client cannot talk to an 8.x server), so staging was moved to 9.2.8. That bump was applied by hardcoding `version: 9.2.8` in the template, which is **shared by every environment** — so the next *production* deploy would attempt to jump prod ES from 8.18.8 straight to 9.2.8. Elasticsearch forbids skipping the 8.19 minor on an 8→9 upgrade, so that deploy would fail and leave prod in a half-upgraded state.

Parameterizing the version lets staging run 9.2.8 while production stays safely on 8.18.8 until it gets its own, properly stepped (8.18 → 8.19 → 9.2), snapshot-gated upgrade.

### Changes
- `templates/elasticsearch.yaml`: `version: 9.2.8` → `version: {{ .Values.es.version }}`
- `values.yaml`: default `es.version: "8.18.8"`
- `values-aws-staging.yaml`: `es.version: "9.2.8"`, `storage: 4Gi`

### Safety
- Renders verified: aws-staging → 9.2.8 / 4Gi (matches the live staging cluster), production / test / okd-staging → 8.18.8.
- No production behaviour change; this only removes the unintended prod 9.2.8 jump.