### PR TITLE
fix(staging): migrate tracing.enabled to tracing.export.enabled for Spring Boot 4

### DIFF
--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -40,7 +40,8 @@ spec:
             {{- if eq $env "staging" }}
             # Staging observability is METRICS-ONLY
             tracing:
-              enabled: false
+              export:
+                enabled: false
             {{- else }}
             zipkin:
               tracing:


### PR DESCRIPTION
Spring Boot 4 renames `management.tracing.enabled` to `management.tracing.export.enabled`. The composed staging `configuration.yml` still used the old key, which the SB4 `PropertiesMigrationListener` rejects on startup:

> Key: management.tracing.enabled — Replacement key 'management.tracing.export.enabled' uses an incompatible target type

This updates the staging branch of the ExternalSecrets template to the new key. Staging is metrics-only, so disabling span export preserves the intended behaviour.

Note: production uses `management.zipkin.tracing.endpoint`, which SB4 also renames (to `management.tracing.export.zipkin.endpoint`). That is intentionally out of scope here (staging-only) and needs a follow-up before production moves to Spring Boot 4.

Refs #11560