### PR TITLE
staging: point Eclipse OIDC at staging auth realm

### DIFF
--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -105,6 +105,12 @@ spec:
                     github:
                       client-id: "{{ "{{" }} .github_client_id {{ "}}" }}"
                       client-secret: "{{ "{{" }} .github_client_secret {{ "}}" }}"
+                {{- if eq $env "staging" }}
+                # Staging uses the staging Eclipse auth realm; prod inherits application.yml (community).
+                provider:
+                  eclipse:
+                    issuer-uri: https://auth-staging.eclipse.org/auth/realms/community-staging
+                {{- end }}
           ovsx:
             elasticsearch:
               # host is env-specific (ECK uses elasticsearch-<env>-es-http); truststore/password not in application.yml.


### PR DESCRIPTION
Staging login currently inherits the production `issuer-uri` baked into `application.yml` (`auth.eclipse.org/.../community`), so it authenticates against the prod Eclipse realm.

This adds a staging-only `provider.eclipse.issuer-uri` override in the ESO-composed config, pointing staging at `auth-staging.eclipse.org/auth/realms/community-staging`. Production is unchanged (still inherits application.yml).

The matching staging client-id/secret are updated separately in AWS Secrets Manager (`openvsx/staging/oauth`); no deploy needed there — ESO resyncs.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>