### PR TITLE
staging: fix Eclipse OIDC issuer-uri indentation

### DIFF
--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -105,12 +105,13 @@ spec:
                     github:
                       client-id: "{{ "{{" }} .github_client_id {{ "}}" }}"
                       client-secret: "{{ "{{" }} .github_client_secret {{ "}}" }}"
-                {{- if eq $env "staging" }}
-                # Staging uses the staging Eclipse auth realm; prod inherits application.yml (community).
-                provider:
-                  eclipse:
-                    issuer-uri: https://auth-staging.eclipse.org/auth/realms/community-staging
-                {{- end }}
+                  {{- if eq $env "staging" }}
+                  # Staging uses the staging Eclipse auth realm; prod inherits application.yml (community).
+                  # Must sit under client: — path is spring.security.oauth2.client.provider.*
+                  provider:
+                    eclipse:
+                      issuer-uri: https://auth-staging.eclipse.org/auth/realms/community-staging
+                  {{- end }}
           ovsx:
             elasticsearch:
               # host is env-specific (ECK uses elasticsearch-<env>-es-http); truststore/password not in application.yml.


### PR DESCRIPTION
Follow-up to #11854. That change added the staging `issuer-uri` override but nested `provider:` under `oauth2:` instead of `client:`, producing the dead key `spring.security.oauth2.provider.eclipse.issuer-uri`. Spring ignored it and staging login kept falling back to the production realm baked in `application.yml` (`auth.eclipse.org/.../community`).

Verified live on staging: the composed `configuration.yml` had `provider` one level too high, and `staging.open-vsx.org/oauth2/authorization/eclipse` still 302'd to the production realm.

This moves `provider:` under `client:` so the path is `spring.security.oauth2.client.provider.eclipse.issuer-uri`. Staging then resolves to `auth-staging.eclipse.org/auth/realms/community-staging`; production is unchanged.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>