### PR TITLE
staging: point ovsx.eclipse.base-url at staging API

### DIFF
--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -113,6 +113,11 @@ spec:
                       issuer-uri: https://auth-staging.eclipse.org/auth/realms/community-staging
                   {{- end }}
           ovsx:
+            {{- if eq $env "staging" }}
+            # Staging Eclipse API base; prod inherits application.yml (api.eclipse.org).
+            eclipse:
+              base-url: https://api-staging.eclipse.org/
+            {{- end }}
             elasticsearch:
               # host is env-specific (ECK uses elasticsearch-<env>-es-http); truststore/password not in application.yml.
               host: "elasticsearch-{{ $env }}-es-http:9200"


### PR DESCRIPTION
Staging should call the staging Eclipse API, but `ovsx.eclipse.base-url` is baked to `https://api.eclipse.org/` in `application.yml` and staging inherits it.

Adds a staging-only override in the ESO-composed config → `https://api-staging.eclipse.org/` (trailing slash kept to match the prod value). Production is unchanged.

Note: this is plain config, not a secret — no AWS Secrets Manager change needed. It rides in `deployment-configuration-staging` only because that file bundles all Spring config.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>