### PR TITLE
Update Elasticsearch version to 8.19.19

### DIFF
--- a/charts/openvsx/templates/elasticsearch.yaml
+++ b/charts/openvsx/templates/elasticsearch.yaml
@@ -57,4 +57,4 @@ spec:
           name: elasticsearch
           resources:
           {{- toYaml .Values.es.resources | nindent 12 }}
-  version: 8.18.8
+  version: 8.19.19


### PR DESCRIPTION
This PR is a prerequisites for deploying v1.1.0.

We need to bump ES first to 8.19.x so that an upgrade to 9.x works automatically.