### PR TITLE
deploy: drop helm auto-rollback, raise timeout to 25m

### DIFF
--- a/kubernetes/helm-deploy.sh
+++ b/kubernetes/helm-deploy.sh
@@ -90,12 +90,16 @@ if [[ -n "${DRY_RUN}" ]]; then
   printf "==> DRY RUN — render + server-side validate, no changes will be applied\n"
   helm_mode_flags=(--dry-run=server --debug)
 else
-  # Helm-version-aware flags:
+  # No auto-rollback: the chart owns an ECK Elasticsearch, and ECK rejects version
+  # downgrades, so a rollback can never succeed — it only leaves the release failed.
+  # Safety comes from the Deployment's maxUnavailable=0: old pods serve until new ones are Ready.
+  # Timeout must stay below the Jenkinsfile job timeout so Helm fails cleanly instead of
+  # being killed mid-operation and leaving the release locked in pending-upgrade.
   helm_major=$(helm version --template '{{.Version}}' | sed -E 's/^v?([0-9]+).*/\1/')
   if (( helm_major >= 4 )); then
-    helm_mode_flags=(--rollback-on-failure --timeout 15m --force-conflicts)
+    helm_mode_flags=(--wait --timeout 25m --force-conflicts)
   else
-    helm_mode_flags=(--atomic --timeout 15m)
+    helm_mode_flags=(--wait --timeout 25m)
   fi
 fi
 


### PR DESCRIPTION
The chart owns an ECK `Elasticsearch` resource, and ECK's admission webhook rejects version downgrades. That makes Helm's auto-rollback unable to ever succeed on this chart: when an upgrade runs long, the rollback fires, tries to lower `spec.version`, gets denied, and leaves the release `failed` with a stored manifest that no longer matches the cluster.

That happened twice during the 2026-08-07 production deploy. The Elasticsearch upgrade itself was fine both times — only the rollback failed:

```
Rollback "production" failed: cannot patch "elasticsearch-production" with kind Elasticsearch:
admission webhook "elastic-es-validation-v1.k8s.elastic.co" denied the request:
spec.version: Invalid value: "8.18.8": Downgrades are not supported
```

The rollout was also reverted to the previous image partway through, so the next deploy had to diff against an inconsistent baseline.

This swaps `--atomic` / `--rollback-on-failure` for plain `--wait`, and raises the timeout from 15m to 25m. The last full production rollout took 13m53s against the 15m limit — 67 seconds of margin.

Nothing is lost by dropping auto-rollback here. The Deployment already sets `maxUnavailable: 0`, so old pods keep serving until new ones are Ready; a bad image stalls the rollout rather than taking the service down. Auto-rollback was not providing safety the Deployment doesn't already provide, and on this chart it actively converted "slow" into "broken".

The timeout stays below the Jenkinsfile's 30-minute job timeout on purpose. If Jenkins kills the job first, Helm dies mid-operation and the release is left locked in `pending-upgrade`, which needs manual intervention to clear — strictly worse than a clean Helm timeout.

Verified with `bash -n` and a `--dry-run=server` against the production cluster.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>
