### PR TITLE
chart: make preStop delay outlast ALB deregistration

### DIFF
--- a/charts/openvsx/templates/deployment.yaml
+++ b/charts/openvsx/templates/deployment.yaml
@@ -93,9 +93,11 @@ spec:
         - secretRef:
             name: deployment-configuration-{{ .Values.environment }}-argus
         lifecycle:
+          # Delay SIGTERM until the load balancer has stopped routing here; must exceed
+          # its deregistration delay or the LB cuts connections mid-response (5xx).
           preStop:
             exec:
-              command: ["sh", "-c", "sleep 25"]
+              command: ["sh", "-c", "sleep {{ .Values.preStopDelaySeconds }}"]
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -9,6 +9,9 @@ host: staging.open-vsx.org
 replicaCount: 6
 esReplicaCount: 3
 
+# Must exceed the ALB deregistration_delay of 30s set in ingress annotations below.
+preStopDelaySeconds: 35
+
 # Enables templates/hpa-postgresql.yaml — HPA on the in-cluster postgresql-ha
 # StatefulSet (3..9 replicas, CPU 60%). aws-staging has postgresql-ha; aws-production
 # uses RDS so this stays unset there.

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -31,6 +31,9 @@ aws-load-balancer-controller:
 replicaCount: 3
 esReplicaCount: 3
 
+# Must exceed the ALB deregistration_delay of 30s set in ingress annotations below.
+preStopDelaySeconds: 35
+
 image:
   repository: ghcr.io/eclipsefdn/openvsx-website
   pullPolicy: Always

--- a/charts/openvsx/values.yaml
+++ b/charts/openvsx/values.yaml
@@ -29,6 +29,10 @@ keda:
 
 replicaCount: 6
 esReplicaCount: 3
+
+# preStop pause before SIGTERM. OKD routes via HAProxy; no ALB deregistration to outlast.
+preStopDelaySeconds: 25
+
 autoscaling:
   enabled: false
 


### PR DESCRIPTION
`preStop` sleeps 25s but the ALB `deregistration_delay` is 30s, so pods begin shutting down while traffic is still routed to them. Every pod replacement produces a burst of 5xx — up to ~1,000/min during a deploy against a 12-25/min baseline. It also fires on routine Karpenter consolidation: 642/min at 11:30 today with no deploy running.

Raises it to 35s for the two AWS environments, which both set `deregistration_delay=30`. Parameterised as `preStopDelaySeconds` so OKD keeps 25s — it routes via HAProxy and has no ALB deregistration to outlast. Fits inside the existing `terminationGracePeriodSeconds: 75`.

Signed-off-by: skettkepalli <sridhar.ettkepalli@eclipse-foundation.org>
