### PR TITLE
fix(staging): stop rebuilding the ES search index on every pod start

### DIFF
--- a/charts/openvsx/values-aws-staging.yaml
+++ b/charts/openvsx/values-aws-staging.yaml
@@ -56,7 +56,10 @@ externalSecrets:
   refreshInterval: 1h
   fastlyLogsBucket: "fastlyopenvsxorgstaging"
   storageBucket: "openvsxorgstaging"
-  elasticsearchClearOnStart: true
+  # Soft init — a pod builds the index only if missing. `true` made every pod start wipe the
+  # shared index; freshness comes from incremental writes + the daily 04:00 UTC JobRunr job.
+  # Hard rebuild on demand: POST /admin/update-search-index.
+  elasticsearchClearOnStart: false
   # Read the ES elastic password straight from the ECK secret (deployment.yaml) instead of SM/ESO —
   # app comes up green on first deploy, no bootstrap script, self-heals on ECK password rotation.
   elasticsearchPasswordFromEck: true


### PR DESCRIPTION
Sets `elasticsearchClearOnStart: false` for aws-staging so the app stops deleting and rebuilding the whole Elasticsearch search index every time a pod starts.

With it enabled, every pod start — deploys and autoscaler scale-ups alike — wipes the shared `extensions` index and rebuilds it from PostgreSQL. All the other replicas keep serving search from that index while it is empty or half-populated, and the rebuild blocks the readiness probe, so pods take roughly twice as long to come online. When two pods start at once they race the delete and the loser exits on `resource_already_exists_exception`.

Turning it off is safe because the index is still built whenever it is genuinely missing, so a fresh cluster self-heals on the next pod start. Freshness comes from the daily JobRunr soft-update and the incremental writes on publish, neither of which depends on this flag; `POST /admin/update-search-index` forces a full rebuild on demand if one is ever needed.

Signed-off-by: Sridhar Ettkepalli <sridhar.ettkepalli@eclipse-foundation.org>
