### PR TITLE
fix(production): stop rebuilding the ES search index on every pod start

### DIFF
--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -161,7 +161,10 @@ externalSecrets:
   refreshInterval: 1h
   fastlyLogsBucket: "fastlyopenvsxorg"
   storageBucket: "openvsxorg"
-  elasticsearchClearOnStart: true
+  # Soft init — a pod builds the index only if missing. `true` made every pod start wipe the
+  # shared index; freshness comes from incremental writes + the daily 04:00 UTC JobRunr job.
+  # Hard rebuild on demand: POST /admin/update-search-index.
+  elasticsearchClearOnStart: false
 
 # ── Grafana Alloy — disabled; monitoring/ TF module manages Alloy cluster-wide with IRSA (OKD nodeSelector won't match EKS) ──
 alloy:


### PR DESCRIPTION
Sets `elasticsearchClearOnStart: false` for production, the same change already merged for aws-staging in #12466.

With it enabled, every pod start — deploys and autoscaler scale-ups alike — wipes the shared `extensions` index and rebuilds it from PostgreSQL, taking 23 to 56 seconds on the production index. The other replicas keep serving search from that index while it is empty or half-populated, and the rebuild blocks the readiness probe, so pods take roughly twice as long to come online. When two pods start together they race the delete, and the loser exits on `resource_already_exists_exception` — that happened during the rollout of Helm revision 27.

Staging has been running with it disabled since yesterday: no pod rebuilds the index on start, the index kept its original creation timestamp through a rollout instead of being recreated, and search returns the full extension count. Turning it off is safe because the index is still built whenever it is genuinely missing, so a fresh cluster self-heals on the next pod start. Freshness comes from the daily JobRunr soft-update and the incremental writes on publish, neither of which depends on this flag; `POST /admin/update-search-index` forces a full rebuild on demand if one is ever needed.

Signed-off-by: Sridhar Ettkepalli <sridhar.ettkepalli@eclipse-foundation.org>
