### PR TITLE
chore: update to v1.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG SERVER_VERSION=v1.1.1
-ARG SERVER_VERSION_STRING=v1.1.1
+ARG SERVER_VERSION=v1.1.2
+ARG SERVER_VERSION_STRING=v1.1.2
 
 # Builder image to compile the website
 FROM ubuntu:24.04 AS builder

--- a/charts/openvsx/templates/external-secrets.yaml
+++ b/charts/openvsx/templates/external-secrets.yaml
@@ -43,10 +43,11 @@ spec:
               export:
                 enabled: false
             {{- else }}
-            zipkin:
-              tracing:
-                # EKS-specific: Alloy runs in monitoring ns (vs OKD's grafana-alloy-production in open-vsx-org).
-                endpoint: "http://grafana-alloy.monitoring.svc.cluster.local:9411/api/v2/spans"
+            tracing:
+              export:
+                zipkin:
+                  # EKS-specific: Alloy runs in monitoring ns (vs OKD's grafana-alloy-production in open-vsx-org).
+                  endpoint: "http://grafana-alloy.monitoring.svc.cluster.local:9411/api/v2/spans"
             {{- end }}
           spring:
             datasource:

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -197,7 +197,7 @@ clamav:
     MAX_SINGLE_FILE_MB: 512
     MAX_RECURSION: 16
     MAX_THREADS: 10
-    SCAN_TIMEOUT_MINUTES: 10
+    SCAN_TIMEOUT_MINUTES: 15
 
 # ── YARA ─────────────────────────────────────────────────────────────────────
 yara:

--- a/charts/openvsx/values-aws.yaml
+++ b/charts/openvsx/values-aws.yaml
@@ -197,7 +197,7 @@ clamav:
     MAX_SINGLE_FILE_MB: 512
     MAX_RECURSION: 16
     MAX_THREADS: 10
-    SCAN_TIMEOUT_MINUTES: 15
+    SCAN_TIMEOUT_MINUTES: 10
 
 # ── YARA ─────────────────────────────────────────────────────────────────────
 yara:

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -285,7 +285,7 @@ ovsx:
         required: true
         async: false
         max-concurrency: 5
-        timeout-minutes: 15
+        timeout-minutes: 10
 
         # Per-scanner HTTP client configuration
         # ClamAV needs longer timeouts for large files
@@ -294,7 +294,7 @@ ovsx:
           default-max-per-route: 10             # Max connections per host
           connection-request-timeout-ms: 60000  # Time to get connection from pool (1 min)
           connect-timeout-ms: 60000             # Time to establish TCP connection (1 min)
-          socket-timeout-ms: 300000             # Time to wait for response (5 min for large files)
+          socket-timeout-ms: 600000             # Time to wait for response (10 min for large files)
 
         start:
           method: POST

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -285,7 +285,7 @@ ovsx:
         required: true
         async: false
         max-concurrency: 5
-        timeout-minutes: 10
+        timeout-minutes: 15
 
         # Per-scanner HTTP client configuration
         # ClamAV needs longer timeouts for large files

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "dependencies": {
-    "openvsx-webui": "1.1.1"
+    "openvsx-webui": "1.1.2"
   },
   "resolutions": {
     "qs": "^6.14.1"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3720,7 +3720,7 @@ __metadata:
     eslint: "npm:^9.39.0"
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-react: "npm:^7.37.0"
-    openvsx-webui: "npm:1.1.1"
+    openvsx-webui: "npm:1.1.2"
     prettier: "npm:^3.8.1"
     rollup-plugin-visualizer: "npm:^7.0.1"
     typescript: "npm:^5.9.0"
@@ -3744,9 +3744,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openvsx-webui@npm:1.1.1":
-  version: 1.1.1
-  resolution: "openvsx-webui@npm:1.1.1"
+"openvsx-webui@npm:1.1.2":
+  version: 1.1.2
+  resolution: "openvsx-webui@npm:1.1.2"
   dependencies:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
@@ -3779,7 +3779,7 @@ __metadata:
     react-helmet-async: "npm:^2.0.5"
     react-infinite-scroller: "npm:^1.2.6"
     react-router: "npm:^7.18.2"
-  checksum: 10/f85b5f2c12514d0c968d727861d4e32abcb3376db9d4e093f7fbd632a37b59ee6d77be41e6cc1544af797dd88af9e47e5d18cf1c20b24f4beebf387ab8d38e47
+  checksum: 10/6451f806ace018cc9655d841be53f3583dc90e6a7971ca71aaac9dc22010ddd5f25edf6422102519f3d05bda2e964decf0d6aedfe9b110a1a6e0cf39e1f43122
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR deploys v1.1.2 to production.

See a list of changes here: https://github.com/eclipse-openvsx/openvsx/releases/tag/v1.1.2

This version is currently also deployed to staging.