### PR TITLE
Deploy v1.2.0 of Open VSX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG SERVER_VERSION=v1.1.2
-ARG SERVER_VERSION_STRING=v1.1.2
+ARG SERVER_VERSION=v1.2.0
+ARG SERVER_VERSION_STRING=v1.2.0
 
 # Builder image to compile the website
 FROM ubuntu:24.04 AS builder

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -99,6 +99,8 @@ management:
 
 springdoc:
   model-and-view-allowed: true
+  api-docs:
+    version: openapi_3_0
   swagger-ui:
     path: /swagger-ui
     docExpansion: list
@@ -125,7 +127,7 @@ bucket4j:
 
 ovsx:
   access-token:
-    prefix: ovsxat_
+    prefix: ovsx
     expiration: 0
     notification: 0
   storage:
@@ -136,8 +138,11 @@ ovsx:
     migration:
       enabled: false
     primary-service: aws
+  server:
+    url: "https://open-vsx.org"
   webui:
-    frontendRoutes: "/extension/**,/namespace/**,/search,/user-settings/**,/admin-dashboard/**,/about,/publisher-agreement-*,/terms-of-use,/members,/adopters,/error"
+    url: "https://open-vsx.org"
+    frontendRoutes: "/extension/**,/namespace/**,/search,/user-settings/**,/admin-dashboard/**,/publish,/about,/publisher-agreement-*,/terms-of-use,/members,/adopters,/error"
     additional-routes: "/.well-known/**"
   eclipse:
     base-url: https://api.eclipse.org/
@@ -158,6 +163,8 @@ ovsx:
       downloads: 2.0
       timestamp: 1.2
   migrations:
+    batch-size: 200
+    cron: '0 */2 * * * *'
     delay:
       seconds: 10800
     once-per-version: true
@@ -179,6 +186,7 @@ ovsx:
     files-webresource:
       tti: PT1H
       max-size: 500
+      max-total-size: 2147483648 # 2 GB
     files-browse:
       tti: PT1H
       max-size: 100
@@ -231,6 +239,12 @@ ovsx:
         "contact": "infrastructure@eclipse-foundation.org"
       }
 
+  trusted-publishing:
+    enabled: true
+    audience: 'https://open-vsx.org'
+    active-providers: 'github'
+    token-expiration: 'PT5M'
+
   # General scanning support
   scanning:
     enabled: true
@@ -274,6 +288,13 @@ ovsx:
       # Timeout & Performance
       timeout-seconds: 10
       timeout-check-interval: 100
+
+    namespace-ownership-check:
+      enabled: true
+      enforced: true
+      required: true
+      check-active-extensions: false
+      gallery-url: 'https://marketplace.visualstudio.com/_apis/public/gallery'
 
     configured:
       # ClamAV REST wrapper - our custom Go service with file-level reporting

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "dependencies": {
-    "openvsx-webui": "1.1.2"
+    "openvsx-webui": "1.2.0"
   },
   "resolutions": {
     "qs": "^6.14.1"

--- a/website/src/menu-content.tsx
+++ b/website/src/menu-content.tsx
@@ -11,12 +11,11 @@
 import { forwardRef, FunctionComponent, PropsWithChildren, useState, useRef, useContext } from 'react';
 import Link from '@mui/material/Link';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import IconButton from '@mui/material/IconButton';
-import { styled, alpha } from '@mui/material/styles';
-import { Link as RouteLink, useNavigate } from 'react-router';
+import { styled } from '@mui/material/styles';
+import { Link as RouteLink } from 'react-router';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
@@ -30,11 +29,10 @@ import HubIcon from '@mui/icons-material/Hub';
 import AccountBoxIcon from '@mui/icons-material/AccountBox';
 import BusinessIcon from '@mui/icons-material/Business';
 import SecurityIcon from '@mui/icons-material/Security';
-import { UserSettingsRoutes } from 'openvsx-webui/lib/pages/user/user-settings-routes';
+import { PublishRoutes } from 'openvsx-webui/lib/pages/publish/publish-routes';
 import { MainContext } from 'openvsx-webui/lib/context';
 import { itemIcon, MobileUserAvatar, headerItem, MenuLink, MenuItemText } from 'openvsx-webui/lib/default/menu-content';
-import { KbdKey } from 'openvsx-webui/lib/components/kbd-key';
-import { useShortcut } from 'openvsx-webui/lib/hooks/use-shortcut';
+import { PublishButton } from 'openvsx-webui/lib/components/publish/publish-button';
 import { LoginComponent } from 'openvsx-webui/lib/default/login';
 import { UserAvatar } from 'openvsx-webui/lib/pages/user/avatar';
 
@@ -70,8 +68,8 @@ export const MobileMenuContent: FunctionComponent = () => {
             }}
           />
         ))}
-      {loginProviders && !location.pathname.startsWith(UserSettingsRoutes.ROOT) && (
-        <MenuItem component={RouteLink} to='/user-settings/extensions'>
+      {loginProviders && !location.pathname.startsWith(PublishRoutes.ROOT) && (
+        <MenuItem component={RouteLink} to={PublishRoutes.ROOT}>
           <MenuItemText>
             <PublishIcon sx={itemIcon} />
             Publish
@@ -219,18 +217,9 @@ const ResourcesTrigger = styled('button')(({ theme }) => ({
 // header stays clean; only Publish and the account control remain top-level.
 export const DefaultMenuContent: FunctionComponent = () => {
   const { loginProviders, user } = useContext(MainContext);
-  const navigate = useNavigate();
   const [resourcesOpen, setResourcesOpen] = useState(false);
   const resourcesAnchor = useRef<HTMLButtonElement | null>(null);
   const closeResources = () => setResourcesOpen(false);
-
-  useShortcut({
-    key: 'p',
-    label: 'Publish',
-    order: 3,
-    callback: () => navigate(UserSettingsRoutes.EXTENSIONS),
-    enabled: !!loginProviders
-  });
 
   return (
     <>
@@ -239,7 +228,6 @@ export const DefaultMenuContent: FunctionComponent = () => {
       </MenuLink>
       <ResourcesTrigger
         ref={resourcesAnchor}
-        type='button'
         onClick={() => setResourcesOpen(true)}
         aria-haspopup='menu'
         aria-expanded={resourcesOpen}
@@ -308,26 +296,7 @@ export const DefaultMenuContent: FunctionComponent = () => {
       </Menu>
       {loginProviders && (
         <>
-          <Button
-            variant='text'
-            color='secondary'
-            component={RouteLink}
-            to={UserSettingsRoutes.EXTENSIONS}
-            sx={(theme) => ({
-              mx: 0.5,
-              px: 2.25,
-              py: 1,
-              fontWeight: 600,
-              fontSize: '0.8125rem',
-              borderRadius: `${theme.shape.borderRadius}px`,
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: '0.4375rem',
-              '&:hover': { backgroundColor: alpha(theme.palette.secondary.main, 0.08) }
-            })}>
-            Publish
-            <KbdKey>p</KbdKey>
-          </Button>
+          <PublishButton />
           {user ? (
             <UserAvatar />
           ) : (

--- a/website/src/page-settings.tsx
+++ b/website/src/page-settings.tsx
@@ -222,23 +222,29 @@ export default function createPageSettings(theme: Theme, prefersDarkMode: boolea
   };
 
   //---------- CLAIM NAMESPACE LINK
-  const claimNamespace: FunctionComponent<{ extension: Extension; sx: SxProps<Theme> }> = ({ sx, extension }) => {
-    const title = `Claiming namespace \`${extension.namespace}\``;
+  // The namespace settings page asks for this without an extension to hand, so the namespace comes
+  // as its own prop. An extension is only passed where one is in view, and the extension overview
+  // offers the link for every extension, so a verified namespace still has to opt out here.
+  const claimNamespace: FunctionComponent<{ namespace: string; extension?: Extension; sx?: SxProps<Theme> }> = ({
+    namespace,
+    extension,
+    sx
+  }) => {
+    if (extension?.verified) {
+      return null;
+    }
+    const title = `Claiming namespace \`${namespace}\``;
 
     return (
-      <>
-        {!extension.verified && (
-          <Link
-            href={`https://github.com/EclipseFdn/open-vsx.org/issues/new?template=claim-namespace-ownership.yml&namespace=${encodeURIComponent(extension.namespace)}&title=${encodeURIComponent(title)}`}
-            target='_blank'
-            variant='body2'
-            color='secondary'
-            underline='hover'
-            sx={sx}>
-            Claim Ownership
-          </Link>
-        )}
-      </>
+      <Link
+        href={`https://github.com/EclipseFdn/open-vsx.org/issues/new?template=claim-namespace-ownership.yml&namespace=${encodeURIComponent(namespace)}&title=${encodeURIComponent(title)}`}
+        target='_blank'
+        variant='body2'
+        color='secondary'
+        underline='hover'
+        sx={sx}>
+        Claim Ownership
+      </Link>
     );
   };
 
@@ -351,7 +357,8 @@ export default function createPageSettings(theme: Theme, prefersDarkMode: boolea
     urls: {
       extensionDefaultIcon: '/default-icon.png',
       namespaceAccessInfo: 'https://github.com/eclipse-openvsx/openvsx/wiki/Namespace-Access',
-      publisherAgreement: '/documents/publisher-agreement-v1.1.md'
+      publisherAgreement: '/documents/publisher-agreement-v1.1.md',
+      trustedPublishing: 'https://github.com/eclipse-openvsx/openvsx/wiki/Trusted-Publishing'
     }
   };
 }

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -4,7 +4,7 @@ import webfontDownload from 'vite-plugin-webfont-dl';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, type PluginOption } from 'vite';
 
-const outRootDir = path.join(__dirname, 'dist');
+const outRootDir = path.join(import.meta.dirname, 'dist');
 
 export default defineConfig(() => ({
   plugins: [react(), webfontDownload(), visualizer() as PluginOption],
@@ -17,7 +17,7 @@ export default defineConfig(() => ({
   },
   resolve: {
     alias: [
-      { find: '@', replacement: path.resolve(__dirname, './src') },
+      { find: '@', replacement: path.resolve(import.meta.dirname, './src') },
       // @mui/icons-material's deep imports (e.g. '@mui/icons-material/Menu') resolve to
       // CJS files that Rolldown's dep optimizer/bundler unwraps incorrectly, yielding the
       // module's exports object instead of the icon component (React error #130). The

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1556,13 +1556,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"attr-accept@npm:^2.2.4":
-  version: 2.2.5
-  resolution: "attr-accept@npm:2.2.5"
-  checksum: 10/474b1c53e62c5b881c745d1f098196f190c8b493245e95d4b0fea9298d3acb56f551868fc12806885277e55e9d8ad3c5963e92d93456f4e4081dfc5190977bfd
-  languageName: node
-  linkType: hard
-
 "available-typed-arrays@npm:^1.0.7":
   version: 1.0.7
   resolution: "available-typed-arrays@npm:1.0.7"
@@ -1737,13 +1730,6 @@ __metadata:
     strip-ansi: "npm:^7.1.0"
     wrap-ansi: "npm:^9.0.0"
   checksum: 10/df43d8d1c6e3254cbb64b1905310d5f6672c595496a3cbe76946c6d24777136886470686f2772ac9edfe547a74bb70e8017530b3554715aee119efd7752fc0d9
-  languageName: node
-  linkType: hard
-
-"clsx@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "clsx@npm:1.2.1"
-  checksum: 10/5ded6f61f15f1fa0350e691ccec43a28b12fb8e64c8e94715f2a937bc3722d4c3ed41d6e945c971fc4dcc2a7213a43323beaf2e1c28654af63ba70c9968a8643
   languageName: node
   linkType: hard
 
@@ -2489,15 +2475,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-selector@npm:^2.1.0":
-  version: 2.1.2
-  resolution: "file-selector@npm:2.1.2"
-  dependencies:
-    tslib: "npm:^2.7.0"
-  checksum: 10/2a6be0e1904df85f8705a5171fd3b93c1b1ff2ad0143556adb78ac4de899bfc0ba1a20083b4febd4f7000759ec9119a31af76a057e29dd9215907da69ac95e50
-  languageName: node
-  linkType: hard
-
 "find-root@npm:^1.1.0":
   version: 1.1.0
   resolution: "find-root@npm:1.1.0"
@@ -3213,13 +3190,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.3.0":
-  version: 4.3.1
-  resolution: "js-yaml@npm:4.3.1"
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/2ce71b5d632abbd77da80447bf860e8a0264e54bffe94840984887d58b023761495b523727547904517a6107a1ef189854b361e0fc44995ee13a84f222d7bd42
+  checksum: 10/05c44b9c73e4901d92703b155e76518df64bf01ac62e4c036b47de4b391e19b72e32656e8954d51b436307f08cc9d0c0d4ec617d061cf2f65fffee9f3114bee7
   languageName: node
   linkType: hard
 
@@ -3720,7 +3697,7 @@ __metadata:
     eslint: "npm:^9.39.0"
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-react: "npm:^7.37.0"
-    openvsx-webui: "npm:1.1.2"
+    openvsx-webui: "npm:1.2.0"
     prettier: "npm:^3.8.1"
     rollup-plugin-visualizer: "npm:^7.0.1"
     typescript: "npm:^5.9.0"
@@ -3744,9 +3721,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openvsx-webui@npm:1.1.2":
-  version: 1.1.2
-  resolution: "openvsx-webui@npm:1.1.2"
+"openvsx-webui@npm:1.2.0":
+  version: 1.2.0
+  resolution: "openvsx-webui@npm:1.2.0"
   dependencies:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
@@ -3763,23 +3740,19 @@ __metadata:
     "@tanstack/react-query": "npm:^5.101.0"
     "@tanstack/react-query-devtools": "npm:^5.101.0"
     clipboard-copy: "npm:^4.0.1"
-    clsx: "npm:^1.2.1"
     dompurify: "npm:^3.0.4"
     fetch-retry: "npm:^5.0.6"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.7.2"
     markdown-it: "npm:^14.1.0"
     markdown-it-anchor: "npm:^9.2.0"
-    prop-types: "npm:^15.8.1"
-    punycode: "npm:^2.3.0"
     react: "npm:^18.2.0"
     react-avatar-editor: "npm:^15.0.0"
     react-dom: "npm:^18.2.0"
-    react-dropzone: "npm:^14.2.3"
     react-helmet-async: "npm:^2.0.5"
     react-infinite-scroller: "npm:^1.2.6"
     react-router: "npm:^7.18.2"
-  checksum: 10/6451f806ace018cc9655d841be53f3583dc90e6a7971ca71aaac9dc22010ddd5f25edf6422102519f3d05bda2e964decf0d6aedfe9b110a1a6e0cf39e1f43122
+  checksum: 10/c49c76cf39e75a861bd1a393578c9a8a996f94497ed2d47ff894d1b97aaa77a0138366329cd45bd077281362240b95f5ce210910d46dc935da538e48594bdebf
   languageName: node
   linkType: hard
 
@@ -3963,7 +3936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0, punycode@npm:^2.3.0":
+"punycode@npm:^2.1.0":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10/febdc4362bead22f9e2608ff0171713230b57aff9dddc1c273aa2a651fbd366f94b7d6a71d78342a7c0819906750351ca7f2edd26ea41b626d87d6a13d1bd059
@@ -3998,19 +3971,6 @@ __metadata:
   peerDependencies:
     react: ^18.3.1
   checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
-  languageName: node
-  linkType: hard
-
-"react-dropzone@npm:^14.2.3":
-  version: 14.4.1
-  resolution: "react-dropzone@npm:14.4.1"
-  dependencies:
-    attr-accept: "npm:^2.2.4"
-    file-selector: "npm:^2.1.0"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    react: ">= 16.8 || 18.0.0"
-  checksum: 10/dd00fd88e6a804d4fe5e82fb2dce4a98416e6094e0950f84045289afc26be320e19b6dae4544be1a3f9fddc744022b1b91d479b05d183d6cf813b97fe1700dcc
   languageName: node
   linkType: hard
 
@@ -4060,8 +4020,8 @@ __metadata:
   linkType: hard
 
 "react-router@npm:^7.18.2":
-  version: 7.18.2
-  resolution: "react-router@npm:7.18.2"
+  version: 7.18.3
+  resolution: "react-router@npm:7.18.3"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -4071,7 +4031,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10/e68aa655e5ec2d4143f66ab3b745c50b8588152d89e4ec66c099625357c6a16dfaee5a7e963a9f4f9fbe0adaa37cf9731d63a108a2c4abfaa00124a06da16c24
+  checksum: 10/b7393d5f5b044cda9c922b3f96629abc442d6b1b85224c28d4aa292cda45ef4cf26792b613f2bc0742701da3ddc77dd0d4a181e7e5b85d1abd6982c9eba278f2
   languageName: node
   linkType: hard
 
@@ -4650,13 +4610,6 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10/d5f1936f5618c6ab6942a97b78802217540ced00e7501862ae1f578d9a3aa189fc06050e64cb8951d21f7088e5fd35f53d2bf0d0370a883861c7b05e993ebc44
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.7.0":
-  version: 2.8.1
-  resolution: "tslib@npm:2.8.1"
-  checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR deploys Open VSX 1.2.0 to production (https://github.com/eclipse-openvsx/openvsx/releases/tag/v1.2.0).

This version is currently deployed to staging, notable changes:

 - enable trusted publishing
 - add namespace ownership check
 - set upper bound for fileresource cache to 2GB
 - explicitly set server and webui urls

The access token prefix was adjusted as the code can now generate different tokens so the prefix had to be adjusted for that.